### PR TITLE
로그인 및 회원가입 토큰 하이브리드 방식 보안 기능 개발

### DIFF
--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/controller/AuthController.java
@@ -2,14 +2,17 @@ package com.ogi1t.bitelearn.domain.auth.controller;
 
 import com.ogi1t.bitelearn.domain.auth.dto.request.LoginRequest;
 import com.ogi1t.bitelearn.domain.auth.dto.request.SignupRequest;
-import com.ogi1t.bitelearn.domain.auth.dto.request.TokenRefreshRequest;
 import com.ogi1t.bitelearn.domain.auth.dto.response.TokenResponse;
 import com.ogi1t.bitelearn.domain.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,23 +35,58 @@ public class AuthController {
 
   @Operation(summary = "로컬 로그인")
   @PostMapping("/login")
-  public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request) {
-    TokenResponse response = authService.login(request);
-    return ResponseEntity.ok(response);
+  public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request, HttpServletResponse response) {
+    TokenResponse tokenResponse = authService.login(request);
+
+    // 로컬 로그인 시에도 Refresh Token은 HttpOnly 쿠키로 굽기
+    setRefreshTokenCookie(response, tokenResponse.getRefreshToken(), 14 * 24 * 60 * 60);
+
+    return ResponseEntity.ok(tokenResponse);
   }
 
   @Operation(summary = "토큰 재발급")
   @PostMapping("/refresh")
-  public ResponseEntity<TokenResponse> refresh(@RequestBody TokenRefreshRequest request) {
-    TokenResponse response = authService.refresh(request);
-    return ResponseEntity.ok(response);
+  public ResponseEntity<TokenResponse> refresh(
+      @CookieValue(name = "refreshToken", required = false) String refreshToken,
+      HttpServletResponse response) {
+
+    if (refreshToken == null) {
+      throw new IllegalArgumentException("Refresh Token이 없습니다."); // 적절한 BusinessException으로 변경
+    }
+
+    TokenResponse tokenResponse = authService.refresh(refreshToken); // DTO 대신 String을 바로 넘김
+
+    // 재발급된 Refresh Token으로 쿠키 갱신
+    setRefreshTokenCookie(response, tokenResponse.getRefreshToken(), 14 * 24 * 60 * 60);
+
+    return ResponseEntity.ok(tokenResponse);
   }
 
   @Operation(summary = "로그아웃")
   @PostMapping("/logout")
-  public ResponseEntity<String> logout(@RequestBody TokenRefreshRequest request) {
-    // 로그아웃 시 Refresh Token을 받아서 DB에서 지움
-    authService.logout(request.getRefreshToken());
+  public ResponseEntity<String> logout(
+      @CookieValue(name = "refreshToken", required = false) String refreshToken,
+      HttpServletResponse response) {
+
+    if (refreshToken != null) {
+      authService.logout(refreshToken);
+    }
+
+    // 쿠키 무효화 (만료시간 0)
+    setRefreshTokenCookie(response, "", 0);
+
     return ResponseEntity.ok("로그아웃 되었습니다.");
+  }
+
+  // 쿠키 생성 공통 메서드
+  private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken, long maxAge) {
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        .maxAge(maxAge)
+        .path("/")
+        .secure(false) // HTTPS일 경우 true
+        .sameSite("Lax")
+        .httpOnly(true)
+        .build();
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/response/TokenResponse.java
@@ -1,5 +1,6 @@
 package com.ogi1t.bitelearn.domain.auth.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +17,9 @@ public class TokenResponse {
 
   private String grantType;    // 보통 "Bearer"
   private String accessToken;  // JWT Access Token
+
+  @JsonIgnore // 응답 바디(JSON) 직렬화 시 이 필드를 제외시킨다!
   private String refreshToken; // JWT Refresh Token
+
   private Long accessTokenExpiresIn; // 액세스 토큰 만료 시간 (밀리초)
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/service/AuthService.java
@@ -2,7 +2,6 @@ package com.ogi1t.bitelearn.domain.auth.service;
 
 import com.ogi1t.bitelearn.domain.auth.dto.request.LoginRequest;
 import com.ogi1t.bitelearn.domain.auth.dto.request.SignupRequest;
-import com.ogi1t.bitelearn.domain.auth.dto.request.TokenRefreshRequest;
 import com.ogi1t.bitelearn.domain.auth.dto.response.TokenResponse;
 import com.ogi1t.bitelearn.domain.auth.entity.RefreshToken;
 import com.ogi1t.bitelearn.domain.auth.entity.enums.ProviderType;
@@ -93,12 +92,12 @@ public class AuthService {
 
   // 3. 토큰 재발급
   @Transactional
-  public TokenResponse refresh(TokenRefreshRequest request) {
-    if (!jwtProvider.validateRefreshToken(request.getRefreshToken())) {
+  public TokenResponse refresh(String refreshToken) {
+    if (!jwtProvider.validateRefreshToken(refreshToken)) {
       throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
     }
 
-    RefreshToken storedToken = refreshTokenRepository.findByToken(request.getRefreshToken())
+    RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken)
         .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
 
     User user = userRepository.findById(storedToken.getUserId())

--- a/src/main/java/com/ogi1t/bitelearn/global/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/security/OAuth2SuccessHandler.java
@@ -2,7 +2,6 @@ package com.ogi1t.bitelearn.global.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ogi1t.bitelearn.domain.auth.entity.RefreshToken;
-import com.ogi1t.bitelearn.domain.auth.dto.response.TokenResponse;
 import com.ogi1t.bitelearn.domain.auth.repository.RefreshTokenRepository;
 import com.ogi1t.bitelearn.domain.user.entity.User;
 import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
@@ -13,6 +12,9 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -26,6 +28,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
   private final RefreshTokenRepository refreshTokenRepository;
   private final UserRepository userRepository;
   private final ObjectMapper objectMapper;
+
+  @Value("${app.frontend-redirect-url}")
+  private String frontendRedirectUrl;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -60,17 +65,19 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         .expiredAt(LocalDateTime.now().plusDays(14))
         .build());
 
-    // 5. 응답 전송 (JSON으로 뿌려주기)
-    // 실제 운영 시에는 프론트엔드 URL로 리다이렉트(sendRedirect) 해야 함
-    // response.sendRedirect("http://localhost:3000/oauth/callback?access=" + accessToken);
-    response.setContentType("application/json;charset=UTF-8");
-    TokenResponse tokenResponse = TokenResponse.builder()
-        .grantType("Bearer")
-        .accessToken(accessToken)
-        .refreshToken(refreshToken)
-        .accessTokenExpiresIn(jwtProvider.getAccessTokenExpirationTime())
+    // 쿠키 설정
+    // 1. Refresh Token을 HttpOnly 쿠키로 설정
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        .maxAge(14 * 24 * 60 * 60) // 14일
+        .path("/")
+        .secure(false) // HTTPS 적용 시 true로 변경 필수
+        .sameSite("Lax") // 프론트/백엔드 도메인 상황에 따라 None 또는 Strict로 변경
+        .httpOnly(true)
         .build();
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-    response.getWriter().write(objectMapper.writeValueAsString(tokenResponse));
+    // 2. Access Token을 쿼리 파라미터에 담아서 프론트엔드로 리다이렉트
+    String targetUrl = frontendRedirectUrl + accessToken;
+    getRedirectStrategy().sendRedirect(request, response, targetUrl);
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,5 @@
 spring:
   application:
     name: bitelearn
+app:
+  frontend-redirect-url: "http://15.164.238.132:3000/oauth/callback?accessToken="


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#5 

## 📝 PR 개요

> 이 PR에서 무엇을 했는지 요약

refreshToken cookie 방식으로 변환

## 📜 변경 사항

- 로컬로그인 : body로 accessToken 주고, refreshToken 쿠키로 줌 - 200 OK
- 소셜로그인 : redirect uri + 파라미터 쿼리에 accessToken + refreshToken 쿠키로 줌 - 302 Redirect