### PR TITLE
QuizType enum 명 변경

### DIFF
--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/QuizType.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/QuizType.java
@@ -2,8 +2,8 @@ package com.ogi1t.bitelearn.domain.learning.entity.enums;
 
 public enum QuizType {
   TEXT_MCQ,       // 일반 객관식
-  DOC_SELECT,     // 문서 선택형 객관식
-  DOC_MULTI,      // 문서 다지선다형
+  DOC_CLICK,      // 문서 클릭형 객관식
+  DOC_MCQ,        // 문서 객관식
   DIALOGUE_MCQ,   // 대화형 객관식
   DIALOGUE_OX     // 대화형 OX
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#25 

## 📝 PR 개요

> 이 PR에서 무엇을 했는지 요약

- DOC_SELECT  -> DOC_CLICK 으로 수정
- DOC_MULTI -> DOC_MCQ 으로 수정


## 📜 변경 사항

- API 명세서 문서화 및 직관성에 더 좋은 enum 명으로 변경
- MySQL 쿼리 변경
- DB 에 수정사항 반영