### PR TITLE
챕터 학습 보상(바이트/레벨) 시스템 구축 및 어뷰징 방지 로직 추가

### DIFF
--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/info/SpecificDataInfo.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/info/SpecificDataInfo.java
@@ -23,6 +23,9 @@ public class SpecificDataInfo {
   @Builder.Default
   private List<DocumentElementInfo> documentElements = new ArrayList<>();
 
+  private String documentTitle;    // 문서 제목 (예: "[표제부]")
+  private String documentSubtitle; // 문서 부제목 (예: "(건물의 표시)")
+
   // --- 내부 클래스 ---
 
   @Getter

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterLearningResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterLearningResponse.java
@@ -23,4 +23,6 @@ public class ChapterLearningResponse {
   private Integer resumeQuizSequence;
   private List<VocabInfo> vocabs;
   private List<QuizInfo> quizzes;
+
+  private String closingMessage;
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterResultResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterResultResponse.java
@@ -9,5 +9,10 @@ public class ChapterResultResponse {
   private int correctCount;
   private int totalCount;
   private int accuracyRate;
+
   private int earnedBytes;
+  private int lostBytes;
+
+  private int currentLevel;
+  private int currentTotalBytes;
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Chapter.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Chapter.java
@@ -33,4 +33,7 @@ public class Chapter {
   private String coreKeywords; // 핵심 내용 키워드
 
   private Integer sequence; // 챕터 순서 (1, 2, 3...)
+
+  @Column(columnDefinition = "TEXT")
+  private String closingMessage; // 마무리 멘트
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/LearningProgress.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/LearningProgress.java
@@ -25,6 +25,10 @@ public class LearningProgress {
 
   private Integer lastSolvedQuizSequence;
 
+  // 보상 수령 여부 (기본값 false)
+  @Column(nullable = false)
+  private boolean isRewarded = false;
+
   @CreationTimestamp
   private LocalDateTime createdAt;
 
@@ -48,5 +52,9 @@ public class LearningProgress {
     if (this.status == ProgressStatus.READY) {
       this.status = ProgressStatus.QUIZ_IN_PROGRESS;
     }
+  }
+
+  public void markAsRewarded() {
+    this.isRewarded = true;
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
@@ -19,8 +19,11 @@ import com.ogi1t.bitelearn.domain.learning.repository.LearningProgressRepository
 import com.ogi1t.bitelearn.domain.learning.repository.QuizRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.VocabularyRepository;
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
 import com.ogi1t.bitelearn.global.exception.BusinessException;
 import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
+import com.ogi1t.bitelearn.global.exception.domain.UserErrorCode;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +43,7 @@ public class LearningService {
   private final QuizRepository quizRepository;
   private final LearningProgressRepository progressRepository;
   private final UserQuizAnswerRepository answerRepository;
+  private final UserRepository userRepository;
 
   // 1. 챕터 목록 조회
   public ChapterListResponse getChaptersByCategoryAndTopic(Long userId, Category category, Topic topic) {
@@ -153,7 +157,6 @@ public class LearningService {
     // 마지막 문제가 아니면 "진행 중" 상태와 함께 '방금 푼 문제 번호'를 저장함
     if (quiz.getSequence() >= totalQuizzes) {
       progress.updateProgress(quiz.getSequence(), ProgressStatus.COMPLETED);
-      // TODO: (선택) 보상(바이트) 지급 로직을 여기에 추가할 수 있습니다.
     } else {
       // 퀴즈를 풀다 나갔다면, DB에는 이 마지막 sequence 번호가 남아있게 됨
       progress.updateProgress(quiz.getSequence(), ProgressStatus.QUIZ_IN_PROGRESS);
@@ -163,21 +166,44 @@ public class LearningService {
   }
 
   // 5. 최종 결과 조회
+  @Transactional
   public ChapterResultResponse getChapterResult(Long userId, Long chapterId) {
     int totalQuizzes = quizRepository.countByChapterId(chapterId);
     int correctQuizzes = answerRepository.countLatestCorrectAnswers(userId, chapterId);
+    int incorrectQuizzes = totalQuizzes - correctQuizzes;
 
-    // 0으로 나누기 방지
     int accuracyRate = totalQuizzes > 0 ? (int) Math.round(((double) correctQuizzes / totalQuizzes) * 100) : 0;
 
-    // 임시 보상 로직 (기획에 따라 변경 가능)
-    int earnedBytes = accuracyRate >= 80 ? 500 : 100;
+    // 유저의 진행도 정보와 회원 정보 가져오기
+    LearningProgress progress = progressRepository.findByUserIdAndChapterId(userId, chapterId)
+        .orElseThrow(() -> new BusinessException(LearningErrorCode.PROGRESS_NOT_FOUND));
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+    final int earnedBytes;
+    final int lostBytes;
+
+    if (progress.isRewarded()) {
+      // 이미 보상을 받은 경우 둘 다 0 처리 (재대입 없이 여기서 최초 할당)
+      earnedBytes = 0;
+      lostBytes = 0;
+    } else {
+      earnedBytes = correctQuizzes * 50;
+      lostBytes = incorrectQuizzes * -20;
+
+      user.addBytes(earnedBytes + lostBytes);
+      progress.markAsRewarded();
+    }
 
     return ChapterResultResponse.builder()
         .correctCount(correctQuizzes)
         .totalCount(totalQuizzes)
         .accuracyRate(accuracyRate)
         .earnedBytes(earnedBytes)
+        .lostBytes(lostBytes)
+        .currentLevel(user.getLevel())
+        .currentTotalBytes(user.getTotalBytes())
         .build();
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
@@ -113,6 +113,7 @@ public class LearningService {
         .resumeQuizSequence(nextQuizSequence) // 저장해둔 마지막 문제 번호 + 1 을 프론트엔드로 내려줌 (이어서 풀 문제 번호)
         .vocabs(vocabs)
         .quizzes(quizzes)
+        .closingMessage(chapter.getClosingMessage())
         .build();
   }
 

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/entity/User.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/entity/User.java
@@ -61,6 +61,30 @@ public class User {
   @Builder.Default
   private boolean isOnboardingCompleted = false;
 
+  @Column(nullable = false)
+  private int totalBytes = 0; // 유저가 보유한 총 바이트 (기본값 0)
+
+  // 바이트 적립 메서드
+  public void addBytes(int bytes) {
+    this.totalBytes += bytes;
+
+    // 방어 로직: 총 보유 바이트가 0 밑으로 떨어지지 않게 막아줌
+    if (this.totalBytes < 0) {
+      this.totalBytes = 0;
+    }
+  }
+
+  // 현재 레벨 계산 메서드 (2000 / 4000 / 6000 기준)
+  public int getLevel() {
+    if (this.totalBytes < 2000) {
+      return 1;
+    } else if (this.totalBytes < 4000) {
+      return 2;
+    } else {
+      return 3; // 4000 이상은 모두 레벨 3 (만렙)
+    }
+  }
+
   // 닉네임 변경 편의 메서드
   public void updateNickname(String newNickname) {
     this.nickname = newNickname;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#32

## 📝 PR 개요

- 유저의 학습 동기를 부여하기 위한 핵심인 **학습 보상(바이트 및 레벨) 시스템**의 기반을 다지는 작업
- 보상 지급 로직과 함께 중복 수급을 막기 위한 어뷰징 방어 로직을 추가하여 시스템의 안정성을 높임
-  프론트엔드 요구사항에 맞추어 문서와 챕터의 디테일한 텍스트 데이터를 내려주기 위한 필드 확장을 진행

## 📜 변경 사항

- **보상 및 레벨 시스템 엔티티 설계**
  - `User`, `LearningProgress` 엔티티에 보상 관련 핵심 필드(현재 레벨, 총 바이트, 잃은 바이트) 추가 및 수정
- **바이트 지급 및 어뷰징 방어 로직 구현**
  - 챕터 완료 시 정답률에 따른 바이트 지급 및 레벨업 계산 로직 추가
  - 부당한 바이트 중복 획득을 막기 위한 `isRewarded` (보상 수급 여부) 필드 및 검증 로직 추가
- **학습 콘텐츠 디테일 필드 확장**
  - 학습 문서(Document)의 가독성을 높이기 위한 `문서 제목`, `문서 부제목` 필드 추가
  - 챕터 완료 결과창에 표시될 `챕터 마무리 멘트` 기능 추가
