### PR TITLE
전체 카테고리 및 토픽 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/controller/LearningController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/controller/LearningController.java
@@ -1,6 +1,7 @@
 package com.ogi1t.bitelearn.domain.learning.controller;
 
 import com.ogi1t.bitelearn.domain.learning.dto.request.QuizSubmitRequest;
+import com.ogi1t.bitelearn.domain.learning.dto.response.CategoryTopicResponse;
 import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterLearningResponse;
 import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterListResponse;
 import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterResultResponse;
@@ -13,6 +14,7 @@ import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
 import com.ogi1t.bitelearn.global.security.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,14 +22,21 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Learning API", description = "학습 API")
 @RestController
-@RequestMapping("/learning/chapters")
+@RequestMapping("/learning")
 @RequiredArgsConstructor
 public class LearningController {
 
   private final LearningService learningService;
 
+  @Operation(summary = "전체 카테고리 및 주제 목록 조회", description = "메인 화면 구성을 위한 대분류(Category) 및 중분류(Topic) 전체 목록을 조회합니다. (비회원 접근 가능)")
+  @GetMapping("/categories")
+  public ResponseEntity<List<CategoryTopicResponse>> getAllCategoriesAndTopics() {
+    List<CategoryTopicResponse> response = learningService.getAllCategoriesAndTopics();
+    return ResponseEntity.ok(response);
+  }
+
   @Operation(summary = "챕터 목록 조회", description = "카테고리와 주제에 맞는 챕터 목록을 조회합니다. (비회원 접근 가능)")
-  @GetMapping
+  @GetMapping("/chapters")
   public ResponseEntity<ChapterListResponse> getChapters(
       @RequestParam Category category,
       @RequestParam Topic topic,
@@ -41,7 +50,7 @@ public class LearningController {
   }
 
   @Operation(summary = "단일 챕터 학습 데이터 조회", description = "챕터 진입 시 단어장과 퀴즈(정답 제외) 데이터를 조회합니다.")
-  @GetMapping("/{chapterId}")
+  @GetMapping("/chapters/{chapterId}")
   public ResponseEntity<ChapterLearningResponse> getChapterLearningData(
       @PathVariable Long chapterId,
       @AuthenticationPrincipal CustomPrincipal principal) {
@@ -56,7 +65,7 @@ public class LearningController {
   }
 
   @Operation(summary = "단어장 완료 처리", description = "단어장 학습을 마치고 퀴즈로 넘어갈 때 진행 상태를 업데이트합니다.")
-  @PostMapping("/{chapterId}/vocab-complete")
+  @PostMapping("/chapters/{chapterId}/vocab-complete")
   public ResponseEntity<Void> completeVocabulary(
       @PathVariable Long chapterId,
       @AuthenticationPrincipal CustomPrincipal principal) {
@@ -71,7 +80,7 @@ public class LearningController {
   }
 
   @Operation(summary = "퀴즈 정답 제출 및 채점", description = "한 문제의 정답을 제출하고 채점 결과를 받습니다.")
-  @PostMapping("/{chapterId}/quizzes/{quizId}")
+  @PostMapping("/chapters/{chapterId}/quizzes/{quizId}")
   public ResponseEntity<QuizSubmitResponse> submitQuiz(
       @PathVariable Long chapterId,
       @PathVariable Long quizId,
@@ -88,7 +97,7 @@ public class LearningController {
   }
 
   @Operation(summary = "챕터 최종 결과 조회", description = "챕터 학습을 마친 후 정답률과 보상 결과를 조회합니다.")
-  @GetMapping("/{chapterId}/result")
+  @GetMapping("/chapters/{chapterId}/result")
   public ResponseEntity<ChapterResultResponse> getChapterResult(
       @PathVariable Long chapterId,
       @AuthenticationPrincipal CustomPrincipal principal) {

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/CategoryTopicResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/CategoryTopicResponse.java
@@ -1,0 +1,22 @@
+package com.ogi1t.bitelearn.domain.learning.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CategoryTopicResponse {
+  private String categoryCode; // 예: "REAL_ESTATE_HOUSING"
+  private String categoryName; // 예: "부동산"
+  private List<TopicDto> topics;
+
+  @Getter
+  @AllArgsConstructor
+  public static class TopicDto {
+    private String topicCode; // 예: "MONTHLY_RENT"
+    private String topicName; // 예: "월세"
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/Category.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/Category.java
@@ -1,7 +1,38 @@
 package com.ogi1t.bitelearn.domain.learning.entity.enums;
 
+import java.util.Arrays;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Category {
-  REAL_ESTATE, // 부동산
-  FINANCE,     // 금융
-  LAW          // 법률 등 (확장 가능)
+
+  REAL_ESTATE_HOUSING("부동산 · 주거", Arrays.asList(
+      Topic.JEONSE,
+      Topic.MONTHLY_RENT,
+      Topic.BUYING
+  )),
+
+  LIVING_FINANCE_EMPLOYMENT("생활금융 · 고용", Arrays.asList(
+      Topic.INCOME_EXPENDITURE,
+      Topic.CREDIT_LIABILITIES,
+      Topic.WORK_WELFARE
+  )),
+
+  CAREER_TAX("커리어 · 세무", Arrays.asList(
+      Topic.SALARY_REAL_INCOME,
+      Topic.INCOME_TAX_DEDUCTION,
+      Topic.COMPREHENSIVE_INCOME_TAX
+  )),
+
+  ASSET_MANAGEMENT_INVESTMENT("자산운용 · 투자", Arrays.asList(
+      Topic.STOCK,
+      Topic.BOND_DEPOSIT,
+      Topic.ANNUITY
+  ));
+
+  private final String description;
+  private final List<Topic> topics;
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/Topic.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/Topic.java
@@ -1,7 +1,31 @@
 package com.ogi1t.bitelearn.domain.learning.entity.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Topic {
-  JEONSE,         // 전세
-  MONTHLY_RENT,   // 월세
-  BUYING          // 매매 등
+
+  // 부동산 · 주거
+  JEONSE("전세"),
+  MONTHLY_RENT("월세"),
+  BUYING("매매"),
+
+  // 생활금융 · 고용
+  INCOME_EXPENDITURE("소득 및 지출"),
+  CREDIT_LIABILITIES("신용 및 부채"),
+  WORK_WELFARE("근로 및 복지"),
+
+  // 커리어 · 세무
+  SALARY_REAL_INCOME("월급과 실수령액"),
+  INCOME_TAX_DEDUCTION("소득공제와 세액공제"),
+  COMPREHENSIVE_INCOME_TAX("종합소득세"),
+
+  // 자산운용 · 투자
+  STOCK("주식"),
+  BOND_DEPOSIT("채권 · 예금"),
+  ANNUITY("연금");
+
+  private final String description; // 프론트엔드에 보여줄 한글 이름
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
@@ -1,6 +1,7 @@
 package com.ogi1t.bitelearn.domain.learning.service;
 
 import com.ogi1t.bitelearn.domain.learning.dto.request.QuizSubmitRequest;
+import com.ogi1t.bitelearn.domain.learning.dto.response.CategoryTopicResponse;
 import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterLearningResponse;
 import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterListResponse;
 import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterResultResponse;
@@ -45,7 +46,31 @@ public class LearningService {
   private final UserQuizAnswerRepository answerRepository;
   private final UserRepository userRepository;
 
-  // 1. 챕터 목록 조회
+  /**
+   * 전체 카테고리(대분류) 및 토픽(중분류) 목록 조회
+   */
+  public List<CategoryTopicResponse> getAllCategoriesAndTopics() {
+    return Arrays.stream(Category.values())
+        .map(category -> {
+          List<CategoryTopicResponse.TopicDto> topicDtos = category.getTopics().stream()
+              .map(topic -> new CategoryTopicResponse.TopicDto(
+                  topic.name(),
+                  topic.getDescription()
+              ))
+              .collect(Collectors.toList());
+
+          return CategoryTopicResponse.builder()
+              .categoryCode(category.name())
+              .categoryName(category.getDescription())
+              .topics(topicDtos)
+              .build();
+        })
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * 챕터 목록 조회
+   */
   public ChapterListResponse getChaptersByCategoryAndTopic(Long userId, Category category, Topic topic) {
     List<Chapter> chapters = chapterRepository.findByCategoryAndTopicOrderBySequenceAsc(category, topic);
     List<Long> chapterIds = chapters.stream().map(Chapter::getId).collect(Collectors.toList());
@@ -71,7 +96,9 @@ public class LearningService {
     return new ChapterListResponse(chapterDtos);
   }
 
-  // 2. 단일 챕터 학습 데이터 조회 (진행도 자동 생성 포함)
+  /**
+   * 단일 챕터 학습 데이터 조회 (진행도 자동 생성 포함)
+   */
   @Transactional
   public ChapterLearningResponse getChapterLearningData(Long userId, Long chapterId) {
     // 챕터 기본 정보 조회
@@ -117,7 +144,9 @@ public class LearningService {
         .build();
   }
 
-  // 3. 단어장 완료 처리 (상태 변경)
+  /**
+   * 단어장 완료 처리 (상태 변경)
+   */
   @Transactional
   public void completeVocabulary(Long userId, Long chapterId) {
     LearningProgress progress = progressRepository.findByUserIdAndChapterId(userId, chapterId)
@@ -126,7 +155,9 @@ public class LearningService {
     progress.startQuiz();
   }
 
-  // 4. 퀴즈 제출 및 채점 (자동 저장)
+  /**
+   * 퀴즈 제출 및 채점 (자동 저장)
+   */
   @Transactional
   public QuizSubmitResponse submitQuizAnswer(Long userId, Long chapterId, Long quizId, QuizSubmitRequest request) {
     // 방어 로직 추가: 답안이 비어있거나 null로 들어왔을 때 튕겨내기
@@ -166,7 +197,9 @@ public class LearningService {
     return new QuizSubmitResponse(isCorrect, quiz.getCorrectAnswer(), quiz.getExplanation(), progress.getStatus());
   }
 
-  // 5. 최종 결과 조회
+  /**
+   * 최종 결과 조회
+   */
   @Transactional
   public ChapterResultResponse getChapterResult(Long userId, Long chapterId) {
     int totalQuizzes = quizRepository.countByChapterId(chapterId);

--- a/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
@@ -47,8 +47,8 @@ public class SecurityConfig {
 
         // 요청에 대한 권한 설정
         .authorizeHttpRequests(auth -> auth
-            // 챕터 목록 조회(GET)는 비회원(토큰 없음)도 접근 허용
-            .requestMatchers(HttpMethod.GET, "/learning/chapters").permitAll()
+            // 카테고리, 토픽, 챕터 목록 조회(GET)는 비회원(토큰 없음)도 접근 허용
+            .requestMatchers(HttpMethod.GET, "/learning/chapters", "/learning/categories").permitAll()
 
             // 인증 없이 접근 가능한 경로
             .requestMatchers(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#34

## 📝 PR 개요

- 메인 화면의 탭 및 메뉴 구성을 위해 프론트엔드에 전체 학습 카테고리(대분류)와 그에 속한 토픽(중분류) 목록을 트리 구조(JSON)로 내려주는 API를 추가했습니다.
- DB 조회를 거치지 않고 서버 메모리에 올라간 Enum 데이터를 기반으로 즉시 응답하여 빠른 속도를 보장하며, 비회원 유저도 메인 화면을 볼 수 있도록 시큐리티 접근 권한을 열어두었습니다.

## 📜 변경 사항

- **Enum 및 DTO 계층 구조 설계**: `Category`가 하위 `Topic` 리스트를 포함하도록 매핑하고, 프론트엔드 렌더링에 최적화된 `CategoryTopicResponse` DTO 생성
- **비즈니스 로직 및 엔드포인트 구현**: DB 조회 없이 `Category.values()`를 읽어 DTO로 변환하는 로직 작성 및 `GET /learning/categories` API 생성
- **시큐리티 접근 권한 허용**: 비회원도 API를 호출할 수 있도록 `SecurityConfig`의 `permitAll()` 목록에 해당 경로 추가