### PR TITLE
오답 노트 데이터 동기화 및 챕터 시퀀스 추가

### DIFF
--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
@@ -22,7 +22,7 @@ public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, 
 
   // 전체 오답 노트 무한 스크롤 조회 (카테고리 조건 없을 때) (uqa.id < :cursor 조건 추가, Pageable 추가)
   @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +
-      "uqa.id, c.id, q.id, c.category, c.topic, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " +
+      "uqa.id, c.id, q.id, c.category, c.topic, c.sequence, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " + // ✨ c.sequence 위치 변경!
       "FROM UserQuizAnswer uqa " +
       "JOIN Quiz q ON uqa.quizId = q.id " +
       "JOIN Chapter c ON uqa.chapterId = c.id " +
@@ -32,7 +32,7 @@ public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, 
 
   // 특정 카테고리의 오답 노트 무한 스크롤 조회 (예: 부동산만 볼 때)
   @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +
-      "uqa.id, c.id, q.id, c.category, c.topic, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " +
+      "uqa.id, c.id, q.id, c.category, c.topic, c.sequence, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " + // ✨ c.sequence 위치 변경!
       "FROM UserQuizAnswer uqa " +
       "JOIN Quiz q ON uqa.quizId = q.id " +
       "JOIN Chapter c ON uqa.chapterId = c.id " +

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteListResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteListResponse.java
@@ -27,6 +27,7 @@ public class IncorrectNoteListResponse {
     private Long quizId;
     private Category category;
     private Topic topic;
+    private Integer chapterSequence;
     private String questionTitle;
     private String userAnswer;
     private String correctAnswer;

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
@@ -10,8 +10,11 @@ import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
 import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteDetailResponse;
 import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse;
 import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse.IncorrectNoteDto;
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
 import com.ogi1t.bitelearn.global.exception.BusinessException;
 import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
+import com.ogi1t.bitelearn.global.exception.domain.UserErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -27,13 +30,17 @@ public class NoteService {
   private final UserQuizAnswerRepository answerRepository;
   private final QuizRepository quizRepository;
   private final ChapterRepository chapterRepository;
+  private final UserRepository userRepository;
 
   // 1. 오답 노트 목록 조회 (무한 스크롤)
   public IncorrectNoteListResponse getIncorrectNoteList(Long userId, Category category, Long cursor) {
     // 총 오답 개수
     int totalCount = answerRepository.countByUserIdAndIsCorrectFalse(userId);
-    // TODO: 유저 보유 바이트 연동 로직 (임시 1250 바이트)
-    int totalBytes = 1250;
+
+    // 실제 유저 정보 조회 및 보유 바이트 연동
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    int totalBytes = user.getTotalBytes();
 
     // 처음 조회 시(cursor가 null) 가장 큰 값을 주어 최신 데이터부터 가져오게 함
     Long actualCursor = (cursor == null) ? Long.MAX_VALUE : cursor;
@@ -89,11 +96,15 @@ public class NoteService {
         .map(chapter -> chapter.getTitle())
         .orElse("알 수 없는 챕터");
 
-    // 총 오답 개수 및 보유 바이트 (상세 화면 상단에도 그려줘야 하므로)
+    // 총 오답 개수 및 보유 바이트
     int totalCount = answerRepository.countByUserIdAndIsCorrectFalse(userId);
-    int totalBytes = 1250;
 
-    // 기존 Learning 도메인의 QuizInfo 재사용 (정답 제외 데이터 세팅)
+    // 실제 유저 정보 조회 및 보유 바이트 연동
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    int totalBytes = user.getTotalBytes();
+
+    // 기존 Learning 도메인의 QuizInfo 재사용
     QuizInfo reusableQuizInfo = QuizInfo.withoutAnswer(quiz);
 
     return IncorrectNoteDetailResponse.builder()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#39

## 📝 PR 개요

- 프론트엔드 오답 노트 화면(목록/상세)이 실제 데이터 기반으로 완벽하게 그려질 수 있도록 API 응답 데이터를 개선했습니다.
- 마이페이지와 동일한 재화(바이트) 값을 바라보도록 하드코딩을 제거했으며, 목록 화면의 문항 카드에 '단원 번호'를 렌더링할 수 있도록 챕터 시퀀스를 응답 객체에 추가했습니다.

## 📜 변경 사항

- **보유 바이트 실제 데이터 연동**: `NoteService`에서 `UserRepository`를 통해 유저를 조회하여, 임시 값(1250) 대신 DB의 실제 `totalBytes`를 반환하도록 수정
- **챕터 시퀀스(단원 번호) 추가**: `IncorrectNoteListResponse.IncorrectNoteDto`에 `chapterSequence` 필드 추가
- **JPQL 쿼리 동기화**: `UserQuizAnswerRepository`의 오답 노트 무한 스크롤 조회 쿼리(전체, 카테고리별) `SELECT` 절에 `chapter.sequence`를 추가하여 DTO에 안전하게 매핑