### PR TITLE
서버 성능 모니터링 환경 구축 (Actuator & Prometheus)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.assertj:assertj-core'  // 더 편한 assertion
+
+    // 성능
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                 "/login/**",
                 "/oauth2/**",
                 "/oauth/**",
+                "/actuator/**",
                 "/v3/api-docs/**",
                 "/swagger-ui/**",
                 "/swagger-ui.html"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,3 +6,11 @@ spring:
     name: bitelearn
 server:
   forward-headers-strategy: framework
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus # 건강 상태와 프로메테우스용 데이터 오픈
+  metrics:
+    tags:
+      application: bitelearn-api # 우리 앱 이름표 달기


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#41 

## 📝 PR 개요

- 실시간 서버 성능 분석 및 병목 현상(Trouble Shooting) 파악을 위해 Spring Boot Actuator와 Prometheus Micrometer를 연동했습니다.
- 애플리케이션 내부의 다양한 메트릭(JVM, CPU, HikariCP 커넥션, HTTP Request 등)을 `/actuator/prometheus` 엔드포인트를 통해 노출합니다.

## 📜 변경 사항

- **의존성 추가**: Actuator 및 Prometheus Micrometer Registry 라이브러리 추가
- **yml 설정**: `/actuator/health` 및 `/actuator/prometheus` 엔드포인트 활성화
- **Security 설정 업데이트**: 외부 모니터링 서버(로컬 Docker의 Prometheus)가 해당 지표를 수집(Scrape)할 수 있도록 `SecurityConfig`의 `permitAll()` 경로에 `/actuator/**` 추가

## 💡 특이 사항 (로컬 모니터링 구조)
- 운영 서버(EC2)의 리소스(RAM 1GB) 최적화 및 부하 분산을 고려하여, 수집 서버(Prometheus)와 시각화 대시보드(Grafana)는 EC2 내부에 설치하지 않습니다.
- 해당 도구들은 로컬 PC의 Docker 컨테이너로 독립 실행되며, 본 PR을 통해 배포된 `https://bitelearn.site/actuator/prometheus`를 원격으로 스크랩하여 모니터링을 수행합니다.