### PR TITLE
오답 노트 API 응답 DTO 구조 변경 (chapterTitle 위치 이동)

### DIFF
--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
@@ -20,9 +20,9 @@ public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, 
       ") AND u.isCorrect = true")
   int countLatestCorrectAnswers(@Param("userId") Long userId, @Param("chapterId") Long chapterId);
 
-  // 전체 오답 노트 무한 스크롤 조회 (카테고리 조건 없을 때) (uqa.id < :cursor 조건 추가, Pageable 추가)
+  // 전체 오답 노트 무한 스크롤 조회 (카테고리 조건 없을 때)
   @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +
-      "uqa.id, c.id, q.id, c.category, c.topic, c.sequence, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " + // ✨ c.sequence 위치 변경!
+      "uqa.id, c.id, q.id, c.category, c.topic, c.title, c.sequence, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " +
       "FROM UserQuizAnswer uqa " +
       "JOIN Quiz q ON uqa.quizId = q.id " +
       "JOIN Chapter c ON uqa.chapterId = c.id " +
@@ -30,16 +30,15 @@ public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, 
       "ORDER BY uqa.id DESC")
   List<IncorrectNoteDto> findAllIncorrectNotesByCursor(@Param("userId") Long userId, @Param("cursor") Long cursor, Pageable pageable);
 
-  // 특정 카테고리의 오답 노트 무한 스크롤 조회 (예: 부동산만 볼 때)
+  // 특정 카테고리의 오답 노트 무한 스크롤 조회
   @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +
-      "uqa.id, c.id, q.id, c.category, c.topic, c.sequence, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " + // ✨ c.sequence 위치 변경!
+      "uqa.id, c.id, q.id, c.category, c.topic, c.title, c.sequence, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " +
       "FROM UserQuizAnswer uqa " +
       "JOIN Quiz q ON uqa.quizId = q.id " +
       "JOIN Chapter c ON uqa.chapterId = c.id " +
       "WHERE uqa.userId = :userId AND uqa.isCorrect = false AND c.category = :category AND uqa.id < :cursor " +
       "ORDER BY uqa.id DESC")
   List<IncorrectNoteDto> findIncorrectNotesByCategoryAndCursor(@Param("userId") Long userId, @Param("category") Category category, @Param("cursor") Long cursor, Pageable pageable);
-
   // 총 오답 개수 카운트
   int countByUserIdAndIsCorrectFalse(Long userId);
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteDetailResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteDetailResponse.java
@@ -15,7 +15,6 @@ public class IncorrectNoteDetailResponse {
   // 오답 노트 메타 정보
   private Long noteId;
   private Long chapterId;
-  private String chapterTitle;
   private LocalDateTime createdAt;
 
   // 내가 제출한 오답과 실제 정답/해설

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteListResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteListResponse.java
@@ -27,6 +27,7 @@ public class IncorrectNoteListResponse {
     private Long quizId;
     private Category category;
     private Topic topic;
+    private String chapterTitle;
     private Integer chapterSequence;
     private String questionTitle;
     private String userAnswer;

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
@@ -4,7 +4,6 @@ import com.ogi1t.bitelearn.domain.learning.dto.info.QuizInfo;
 import com.ogi1t.bitelearn.domain.learning.entity.Quiz;
 import com.ogi1t.bitelearn.domain.learning.entity.UserQuizAnswer;
 import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
-import com.ogi1t.bitelearn.domain.learning.repository.ChapterRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.QuizRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
 import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteDetailResponse;
@@ -29,7 +28,6 @@ public class NoteService {
 
   private final UserQuizAnswerRepository answerRepository;
   private final QuizRepository quizRepository;
-  private final ChapterRepository chapterRepository;
   private final UserRepository userRepository;
 
   // 1. 오답 노트 목록 조회 (무한 스크롤)
@@ -91,11 +89,6 @@ public class NoteService {
     Quiz quiz = quizRepository.findById(note.getQuizId())
         .orElseThrow(() -> new BusinessException(LearningErrorCode.QUIZ_NOT_FOUND));
 
-    // 챕터 아이디로 챕터 제목을 가져오기
-    String chapterTitle = chapterRepository.findById(note.getChapterId())
-        .map(chapter -> chapter.getTitle())
-        .orElse("알 수 없는 챕터");
-
     // 총 오답 개수 및 보유 바이트
     int totalCount = answerRepository.countByUserIdAndIsCorrectFalse(userId);
 
@@ -112,7 +105,6 @@ public class NoteService {
         .totalBytes(totalBytes)
         .noteId(note.getId())
         .chapterId(note.getChapterId())
-        .chapterTitle(chapterTitle)
         .createdAt(note.getCreatedAt())
         .userAnswer(note.getSelectedAnswer())
         .correctAnswer(quiz.getCorrectAnswer())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#44 

## 📝 PR 개요

- 화면 UI 요구사항 변경에 맞추어, 오답 노트 리스트에서 챕터 제목(`chapterTitle`)을 바로 렌더링할 수 있도록 응답 DTO 구조를 리팩토링했습니다.
- 반대로 상세 페이지에서는 더 이상 사용하지 않는 챕터 제목 필드를 제거하여 API 응답 크기를 최적화했습니다.

## 📜 변경 사항

- **DTO 수정:** `IncorrectNoteDetailResponse` 내 `chapterTitle` 필드를 삭제하고, `IncorrectNoteListResponse.IncorrectNoteDto`로 이동
- **Repository 수정:** `UserQuizAnswerRepository` 내 무한 스크롤 조회 JPQL(전체/카테고리별)의 `SELECT new` 생성자 파라미터에 `c.title` 매핑 및 DTO 선언 순서와 완벽 일치
- **Service 수정:** `NoteService.getIncorrectNoteDetail()`에서 챕터 엔티티를 별도로 단건 조회하던 불필요한 로직 제거

## 💬 특이 사항
- DB 스키마(`Entity`)나 데이터 저장 로직(`Insert`) 변경 없이, 순수하게 응답용 `DTO`와 JPQL `Select` 절만 수정한 작업입니다. 따라서 기존 저장된 퀴즈 및 오답 노트 데이터의 무결성에는 전혀 영향이 없습니다.
- Repository의 JPQL 쿼리와 DTO 생성자의 파라미터 순서 및 타입(`topic`, `chapterTitle`, `chapterSequence`) 매칭을 꼼꼼히 검증 완료했습니다.
