### PR TITLE
오답 노트 무한 스크롤 조회 성능 개선 (복합 인덱스 추가)

### DIFF
--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/UserQuizAnswer.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/UserQuizAnswer.java
@@ -9,6 +9,10 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
+@Table(name = "user_quiz_answer", indexes = {
+    // 유저의 오답 노트를 빠르게 조회하고 최신순으로 정렬하기 위한 복합 인덱스
+    @Index(name = "idx_user_correct_id", columnList = "user_id, is_correct, id DESC")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserQuizAnswer {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#46 

## 📝 PR 개요

오답 노트 무한 스크롤 조회 API의 응답 속도 저하 문제를 해결하기 위해
UserQuizAnswer 테이블에 복합 인덱스를 도입하여 쿼리 조회 성능을 최적화했습니다.

## 📜 변경 사항

- `UserQuizAnswer` 엔티티 상단에 복합 인덱스(`idx_user_correct_id`) 추가
- 인덱스 구성 컬럼: `user_id`, `is_correct`, `id DESC`

## 📸 스크린샷 (선택)  

<img width="2032" height="1167" alt="부하테스트 결과 캡처본_01" src="https://github.com/user-attachments/assets/4b84a725-c179-438a-94fb-a447c266feb0" />

<img width="2032" height="1167" alt="부하테스트 결과 캡처본_02" src="https://github.com/user-attachments/assets/fda02a03-612b-4fe2-9a79-460c00a13e6b" />

<img width="2032" height="1167" alt="부하테스트 결과 캡처본_03" src="https://github.com/user-attachments/assets/283f0f4e-c422-4cb2-992c-29582f498f0f" />

<img width="2032" height="1167" alt="부하테스트 결과 캡처본_04" src="https://github.com/user-attachments/assets/738f4848-00d4-480d-9bc6-954ded8d1265" />