### PR TITLE
대시보드 랜덤 학습 추천 API 구현

### DIFF
--- a/src/main/java/com/ogi1t/bitelearn/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/dashboard/controller/DashboardController.java
@@ -1,0 +1,39 @@
+package com.ogi1t.bitelearn.domain.dashboard.controller;
+
+import com.ogi1t.bitelearn.domain.dashboard.dto.response.RecommendedChapterResponse;
+import com.ogi1t.bitelearn.domain.dashboard.service.DashboardService;
+import com.ogi1t.bitelearn.global.exception.BusinessException;
+import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
+import com.ogi1t.bitelearn.global.security.CustomPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Dashboard API", description = "대시보드(홈 화면) API")
+@RestController
+@RequestMapping("/dashboards")
+@RequiredArgsConstructor
+public class DashboardController {
+
+  private final DashboardService dashboardService;
+
+  @Operation(summary = "랜덤 학습 챕터 추천", description = "홈 화면에 노출될 랜덤 학습 챕터 2개를 추천합니다. 유저가 한 번도 학습하지 않은 완전히 새로운 토픽을 우선적으로 노출하여 학습의 다양성을 제공합니다.")
+  @GetMapping("/recommendations")
+  public ResponseEntity<List<RecommendedChapterResponse>> getRecommendations(
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    // 비회원 접근 차단 (유저의 기존 학습 기록을 기반으로 추천해야 하므로 로그인 필수)
+    if (principal == null) {
+      throw new BusinessException(LearningErrorCode.UNAUTHORIZED_ACCESS);
+    }
+
+    List<RecommendedChapterResponse> response = dashboardService.getRandomRecommendations(principal.getUserId());
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/dashboard/dto/response/RecommendedChapterResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/dashboard/dto/response/RecommendedChapterResponse.java
@@ -1,0 +1,29 @@
+package com.ogi1t.bitelearn.domain.dashboard.dto.response;
+
+import com.ogi1t.bitelearn.domain.learning.entity.Chapter;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Topic;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RecommendedChapterResponse {
+  private Long chapterId;
+  private Category category;
+  private Topic topic;
+  private String title;
+  private String prologueSubtitle;
+  private Integer sequence;
+
+  public static RecommendedChapterResponse from(Chapter chapter) {
+    return RecommendedChapterResponse.builder()
+        .chapterId(chapter.getId())
+        .category(chapter.getCategory())
+        .topic(chapter.getTopic())
+        .title(chapter.getTitle())
+        .prologueSubtitle(chapter.getPrologueSubtitle())
+        .sequence(chapter.getSequence())
+        .build();
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/dashboard/service/DashboardService.java
@@ -1,0 +1,81 @@
+package com.ogi1t.bitelearn.domain.dashboard.service;
+
+import com.ogi1t.bitelearn.domain.dashboard.dto.response.RecommendedChapterResponse;
+import com.ogi1t.bitelearn.domain.learning.entity.Chapter;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Topic;
+import com.ogi1t.bitelearn.domain.learning.repository.ChapterRepository;
+import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DashboardService {
+
+  private final ChapterRepository chapterRepository;
+  private final UserQuizAnswerRepository answerRepository;
+
+  public List<RecommendedChapterResponse> getRandomRecommendations(Long userId) {
+    // 1. 유저가 시도한 챕터 ID 목록 조회
+    List<Long> attemptedChapterIds = answerRepository.findAttemptedChapterIdsByUserId(userId);
+
+    // 2. 전체 챕터 조회
+    List<Chapter> allChapters = chapterRepository.findAll();
+
+    // 3. 유저가 이미 건드린 '토픽' 목록 추출
+    Set<Topic> touchedTopics = allChapters.stream()
+        .filter(c -> attemptedChapterIds.contains(c.getId()))
+        .map(Chapter::getTopic)
+        .collect(Collectors.toSet());
+
+    // 4. 아직 풀지 않은 전체 챕터 필터링
+    List<Chapter> unattemptedChapters = allChapters.stream()
+        .filter(c -> !attemptedChapterIds.contains(c.getId()))
+        .collect(Collectors.toList());
+
+    // 5. '아예 안 건드린 토픽'과 '건드리긴 했지만 남은 챕터가 있는 토픽' 분리
+    List<Chapter> untouchedTopicChapters = unattemptedChapters.stream()
+        .filter(c -> !touchedTopics.contains(c.getTopic()))
+        .collect(Collectors.toList());
+
+    List<Chapter> touchedTopicChapters = unattemptedChapters.stream()
+        .filter(c -> touchedTopics.contains(c.getTopic()))
+        .collect(Collectors.toList());
+
+    // 6. 각 토픽별로 가장 앞 번호(sequence)의 챕터만 후보로 선정 후 섞기
+    List<Chapter> candidates = new ArrayList<>();
+    candidates.addAll(pickFirstChaptersAndShuffle(untouchedTopicChapters)); // 우선순위 1: 완전 새로운 토픽
+    candidates.addAll(pickFirstChaptersAndShuffle(touchedTopicChapters));   // 우선순위 2: 풀다 만 토픽
+
+    // 7. 상위 2개 추출하여 DTO 변환 (남은 챕터가 1개 이하면 있는 만큼만 반환)
+    return candidates.stream()
+        .limit(2)
+        .map(RecommendedChapterResponse::from)
+        .collect(Collectors.toList());
+  }
+
+  // 토픽별로 가장 순서가 빠른 챕터 1개씩만 뽑아서 랜덤으로 섞어주는 헬퍼 메서드
+  private List<Chapter> pickFirstChaptersAndShuffle(List<Chapter> chapters) {
+    Map<Topic, Optional<Chapter>> minSeqByTopic = chapters.stream()
+        .collect(Collectors.groupingBy(Chapter::getTopic,
+            Collectors.minBy(Comparator.comparing(Chapter::getSequence))));
+
+    List<Chapter> distinctChapters = minSeqByTopic.values().stream()
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toList());
+
+    Collections.shuffle(distinctChapters); // 랜덤 추천을 위한 셔플
+    return distinctChapters;
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
@@ -41,4 +41,7 @@ public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, 
   List<IncorrectNoteDto> findIncorrectNotesByCategoryAndCursor(@Param("userId") Long userId, @Param("category") Category category, @Param("cursor") Long cursor, Pageable pageable);
   // 총 오답 개수 카운트
   int countByUserIdAndIsCorrectFalse(Long userId);
+
+  @Query("SELECT DISTINCT u.chapterId FROM UserQuizAnswer u WHERE u.userId = :userId")
+  List<Long> findAttemptedChapterIdsByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#48 

## 📝 PR 개요

홈 화면(대시보드)에서 유저에게 새로운 학습 동기를 부여하기 위해,
아직 시도하지 않은 완전히 새로운 토픽의 챕터들을 우선적으로 선정하여 랜덤 추천(2개)해 주는 API를 구현했습니다.

## 📜 변경 사항

- **Dashboard 도메인 신규 생성:** `DashboardController`, `DashboardService` 추가
- **추천 로직 구현:** - DB 쿼리 복잡도를 줄이기 위해, 전체 챕터(48개 고정)를 메모리에 올려 Java Stream을 활용하여 필터링 및 셔플 진행
  - 1순위: 아예 안 건드린 토픽의 가장 앞 번호 챕터
  - 2순위: 건드리긴 했지만 아직 풀지 않은 남은 챕터
- **API 명세화:** Swagger 어노테이션 적용 및 비회원(`CustomPrincipal == null`) 접근 차단 로직 포함