### PR TITLE
Note 및 Dashboard 도메인 전용 에러 코드 분리

### DIFF
--- a/src/main/java/com/ogi1t/bitelearn/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/dashboard/controller/DashboardController.java
@@ -3,7 +3,7 @@ package com.ogi1t.bitelearn.domain.dashboard.controller;
 import com.ogi1t.bitelearn.domain.dashboard.dto.response.RecommendedChapterResponse;
 import com.ogi1t.bitelearn.domain.dashboard.service.DashboardService;
 import com.ogi1t.bitelearn.global.exception.BusinessException;
-import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
+import com.ogi1t.bitelearn.global.exception.domain.DashboardErrorCode;
 import com.ogi1t.bitelearn.global.security.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,7 +30,7 @@ public class DashboardController {
 
     // 비회원 접근 차단 (유저의 기존 학습 기록을 기반으로 추천해야 하므로 로그인 필수)
     if (principal == null) {
-      throw new BusinessException(LearningErrorCode.UNAUTHORIZED_ACCESS);
+      throw new BusinessException(DashboardErrorCode.UNAUTHORIZED_ACCESS);
     }
 
     List<RecommendedChapterResponse> response = dashboardService.getRandomRecommendations(principal.getUserId());

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
@@ -13,6 +13,7 @@ import com.ogi1t.bitelearn.domain.user.entity.User;
 import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
 import com.ogi1t.bitelearn.global.exception.BusinessException;
 import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
+import com.ogi1t.bitelearn.global.exception.domain.NoteErrorCode;
 import com.ogi1t.bitelearn.global.exception.domain.UserErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -78,11 +79,11 @@ public class NoteService {
   public IncorrectNoteDetailResponse getIncorrectNoteDetail(Long userId, Long noteId) {
     // 오답 기록 조회
     UserQuizAnswer note = answerRepository.findById(noteId)
-        .orElseThrow(() -> new BusinessException(LearningErrorCode.NOTE_NOT_FOUND));
+        .orElseThrow(() -> new BusinessException(NoteErrorCode.NOTE_NOT_FOUND));
 
     // 권한 검증 (내 오답 노트가 맞는지)
     if (!note.getUserId().equals(userId)) {
-      throw new BusinessException(LearningErrorCode.UNAUTHORIZED_ACCESS);
+      throw new BusinessException(NoteErrorCode.UNAUTHORIZED_NOTE_ACCESS);
     }
 
     // 퀴즈 원본 데이터 조회

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/domain/DashboardErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/domain/DashboardErrorCode.java
@@ -1,0 +1,17 @@
+package com.ogi1t.bitelearn.global.exception.domain;
+
+import com.ogi1t.bitelearn.global.exception.ApiCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum DashboardErrorCode implements ApiCode {
+
+  UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED.value(), 401, "대시보드 추천 학습을 보려면 로그인이 필요합니다.");
+
+  private final Integer httpStatus;
+  private final Integer code;
+  private final String message;
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/domain/LearningErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/domain/LearningErrorCode.java
@@ -13,8 +13,7 @@ public enum LearningErrorCode implements ApiCode {
   CHAPTER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 챕터입니다."),
   QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 퀴즈입니다."),
   PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "학습 진행도 정보를 찾을 수 없습니다."),
-  INVALID_QUIZ_SUBMISSION(HttpStatus.BAD_REQUEST.value(), 400, "잘못된 퀴즈 제출 요청입니다."),
-  NOTE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 오답 노트입니다.");
+  INVALID_QUIZ_SUBMISSION(HttpStatus.BAD_REQUEST.value(), 400, "잘못된 퀴즈 제출 요청입니다.");
 
   private final Integer httpStatus;
   private final Integer code;

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/domain/NoteErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/domain/NoteErrorCode.java
@@ -1,0 +1,18 @@
+package com.ogi1t.bitelearn.global.exception.domain;
+
+import com.ogi1t.bitelearn.global.exception.ApiCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum NoteErrorCode implements ApiCode {
+
+  NOTE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 오답 노트 기록입니다."),
+  UNAUTHORIZED_NOTE_ACCESS(HttpStatus.FORBIDDEN.value(), 403, "본인의 오답 노트만 조회할 수 있습니다.");
+
+  private final Integer httpStatus;
+  private final Integer code;
+  private final String message;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#50 

## 📝 PR 개요

시스템의 규모가 커짐에 따라 각 도메인의 독립적인 예외 처리를 위해,
기존 LearningErrorCode에 의존하던 부분들을 떼어내어 Note와 Dashboard 전용 에러 코드로 리팩토링했습니다.

## 📜 변경 사항

- `NoteErrorCode` 신규 생성 및 `NoteService` 상세 조회 에러 적용
- `DashboardErrorCode` 신규 생성 및 `DashboardController` 인증 에러 적용