### PR TITLE
BiteLearn v1.0.0 (MVP) 운영 환경 정식 배포

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,6 @@ replay_pid*
 ############################
 # ETC
 ############################
-application-dev.yaml
+application*.yml
+application*.yaml
+application.yaml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,137 @@
+# 📚 BiteLearn Backend
+> 사회 초년생을 위한 부동산·금융·세무 마이크로 러닝 플랫폼, **BiteLearn**의 백엔드 리포지토리
+
+<br>
+
+## 📑 목차 (Table of Contents)
+- [🛠️ Tech Stack](#️-tech-stack)
+- [🗄️ Database Modeling](#️-database-modeling)
+- [🏗️ System Architecture](#️-system-architecture)
+- [📁 Package Structure](#-package-structure)
+- [✨ Core Features](#-core-features)
+- [🔥 Troubleshooting](#-troubleshooting)
+
+<br>
+
+## 🛠️ Tech Stack
+
+### Backend
+* **Java 17 & Spring Boot 3.x** : 객체지향적 설계 및 풍부한 생태계를 활용한 안정적인 비즈니스 로직 구현
+* **Spring Data JPA & QueryDSL** : 객체 중심의 도메인 설계(ORM) 도입 및 유지보수성 향상, 커서 기반 무한 스크롤 등 복잡한 동적 쿼리의 타입 세이프(Type-Safe)한 처리
+
+### Database
+* **MySQL (Amazon RDS)** : 복잡한 학습 기록(퀴즈, 오답 노트)과 유저 데이터 간의 엄격한 데이터 정합성 보장
+
+### Infrastructure & DevOps
+* **AWS (EC2, ALB, Route 53, S3)**
+  * `Route 53 + ALB`: 전 구간 HTTPS 암호화 통신 구축 및 트래픽 분산
+  * `S3`: 미디어 파일(이미지 등) 분리 저장을 통한 서버 무상태(Stateless) 아키텍처 실현
+* **Docker & Jenkins** : 컨테이너화를 통한 실행 환경 의존성 제거 및 CI/CD 파이프라인 자동화로 수동 배포 시 발생하는 휴먼 에러 방지
+
+### Security & Auth
+* **Spring Security & JWT** : 무상태(Stateless) 기반의 빠르고 안전한 인증/인가 시스템 구축
+* **OAuth 2.0 (Google, Naver)** : 사용자 가입 이탈률 최소화 및 민감 정보 보안 리스크 외부 위임
+* **보안 최적화** : Refresh Token에 `HttpOnly`, `Secure`, `SameSite=None` 쿠키 정책을 적용하여 XSS 및 CSRF 공격 원천 방어
+
+---
+
+## 🗄️ Database Modeling
+
+<img width="500" alt="bitelearn ERD Diagram" src="https://github.com/user-attachments/assets/d066d290-f130-4260-8813-f752f26880df" />
+
+
+### 데이터베이스 모델링 및 설계 주안점
+1. **확장성을 고려한 유저-소셜 계정 분리 (`users` & `oauth_accounts`)**
+   유저 테이블에 소셜 정보를 종속시키지 않고 `oauth_accounts` 테이블을 1:N 연관 관계로 분리하여, 하나의 로컬 계정에 여러 개의 소셜 계정을 연동할 수 있는 확장성을 확보했습니다.
+2. **다형성을 고려한 JSON 타입 활용 (`quiz.specificData`)**
+   다양한 퀴즈 타입(객관식, 대화형, 문서 클릭형 등)에 따라 필요한 데이터 규격이 다릅니다. 이를 수많은 컬럼이나 상속 맵핑으로 낭비하는 대신, MySQL의 `JSON` 타입을 활용하여 유연하게 데이터를 저장하도록 모델링했습니다.
+3. **정적 데이터의 Enum 처리로 JOIN 최소화 (`Category`, `Topic`)**
+   변경이 잦지 않은 대/중분류 카테고리를 DB 테이블 대신 애플리케이션 레벨의 Enum 타입으로 관리하여 DB I/O 부하를 줄이고 읽기 성능을 최적화했습니다.
+4. **Stateless 아키텍처를 보완하는 토큰 관리 (`refresh_tokens`)**
+   JWT 탈취 위험 방지 및 안전한 유효기간 관리를 위해 `refresh_tokens` 테이블을 설계하고 만료 시간(`expiredAt`)을 저장하여, 서버 단에서 세션을 주도적으로 제어할 수 있는 보안 토대를 마련했습니다.
+
+---
+
+## 🏗️ System Architecture
+
+<img width="700" alt="bitelearn 시스템 아키텍처 diagram" src="https://github.com/user-attachments/assets/1c0f455c-0342-44ef-87a1-e2ec329ebc46" />
+
+
+### 시스템 아키텍처 설계 주안점
+1. **프론트/백엔드 완전 분리 및 Vercel 배포**: 클라이언트는 Vercel의 글로벌 CDN망을 통해 빠르게 서빙하고, 데이터 트래픽은 AWS 인프라로 분리하여 각 서버의 부하를 독립적으로 제어합니다.
+2. **전 구간 HTTPS 및 보안 통신 구축**: Route 53으로 도메인을 관리하고, AWS ALB에 ACM 인증서를 부착해 브라우저부터 로드밸런서까지 안전한 HTTPS 암호화 통신을 구현했습니다. (소셜 로그인 Mixed Content 및 쿠키 SameSite 보안 이슈 해결)
+3. **AWS S3 연동을 통한 Stateless 서버 지향**: 퀴즈 및 단어장에 사용되는 미디어 이미지 파일들을 EC2 내부에 저장하지 않고 S3로 분리하여 서버의 디스크 I/O 부하를 줄이고 Scale-out 제약 사항을 해소했습니다.
+4. **Jenkins & Docker 기반 CI/CD 파이프라인**: GitHub에 코드가 Push 되면 Webhook을 통해 Jenkins가 빌드를 트리거하고, Docker 이미지로 패키징하여 배포까지 원클릭으로 이어지는 견고한 자동화를 구축했습니다.
+
+---
+
+## 📁 Package Structure
+
+```text
+src/main/java/com/ogi1t/bitelearn
+├── global                      # 전역 설정 및 공통 관심사(Cross-Cutting)
+│   ├── config                  # Security, CORS, Swagger, JPA Auditing 설정
+│   ├── exception               # GlobalExceptionHandler, Custom Error Codes
+│   └── security                # JWT Provider, Custom UserDetailsService
+│
+└── domain                      # 비즈니스 도메인별 모듈 분리 (DDD-lite)
+    ├── auth                    # 로그인, 회원가입, JWT, 소셜(OAuth) 계정 매핑
+    ├── user                    # 유저 정보, 마이페이지, 재화(Bytes) 관리
+    ├── learning                # 챕터, 퀴즈(객관식/OX), 단어장, 학습 진행도
+    └── note                    # 오답 노트 (스냅샷 패턴 적용)
+        │
+        ├── controller          # REST API 진입점 (@RestController)
+        ├── service             # 핵심 비즈니스 로직 (@Transactional)
+        ├── repository          # DB 접근 레이어 (Spring Data JPA)
+        ├── entity              # JPA 엔티티 및 Enum (Category, Topic 등)
+        └── dto                 # Request/Response 및 Validation(@Valid) 객체
+```
+
+---
+
+## ✨ Core Features
+
+### 1. 회원 및 보안 시스템 (Auth & Security)
+* **통합 로그인 시스템**: 자체(Local) 회원가입 및 소셜 로그인(Google, Naver OAuth 2.0) 통합 구현
+* **보안 토큰 관리**: JWT 기반 인증 및 XSS/CSRF 방어를 위한 `HttpOnly`, `Secure` 설정의 Refresh Token 쿠키 발급
+* **안전한 회원 관리**: 정규식을 활용한 비밀번호 유효성 검증 및 회원 정보(닉네임, 온보딩 상태) 관리 API 제공
+
+### 2. 마이크로 러닝 및 퀴즈 (Learning & Quiz)
+* **계층형 학습 구조**: 4대 카테고리(부동산, 생활금융, 세무, 자산운용) 기반의 체계적인 챕터 및 토픽 제공
+* **단어카드 학습**: 챕터별 핵심 키워드를 예습할 수 있는 양면 단어장 제공
+* **다양한 퀴즈 시스템**: 일반 객관식, 대화형 OX, 문서 클릭형 등 5가지 퀴즈 유형(`QuizType`)에 맞춘 유연한 JSON 데이터 모델링 및 채점 로직 구현
+
+### 3. 데이터 무결성 기반 오답 노트 (Incorrect Note)
+* **스냅샷 패턴 적용**: 퀴즈 원본 데이터 수정·삭제 시에도 유저의 과거 학습 기록이 보존되도록 비정규화(Denormalization)된 데이터 스냅샷 저장
+* **무한 스크롤 최적화**: 대용량 데이터 조회를 대비해 커서 기반 페이지네이션(No-Offset)을 적용
+* **맞춤형 복습**: 특정 카테고리 필터링 조회 및 프론트엔드 렌더링을 위한 챕터 시퀀스(단원 번호) 동기화 제공
+
+### 4. 학습 진행도 및 게이미피케이션 (Progress & Gamification)
+* **실시간 진행도 트래킹**: 유저의 챕터별 학습 상태(시작 전, 진행 중, 완료) 및 마지막 풀이 위치 자동 저장
+* **이어하기 기능**: 마이페이지에서 가장 최근 학습 챕터와 진행률(%)을 계산하여 즉시 이어갈 수 있는 동적 데이터 응답
+* **보상 및 레벨 시스템**: 학습 완료 시 자체 재화 '바이트(Bytes)' 적립 및 누적 바이트 기반 자동 레벨 산정 로직 구현
+
+---
+
+## 🔥 Troubleshooting
+
+### 1. 대용량 데이터를 고려한 커서 기반 페이지네이션 및 무한 스크롤 API 설계
+* **문제 상황**: 초기 오답 노트 목록 API는 오프셋(Offset) 방식으로 설계되어, 페이지가 뒤로 갈수록 성능 저하($O(N)$ 시간 복잡도)와 실시간 데이터 변동 시 정합성 문제(중복 노출/누락)가 우려되었습니다.
+* **해결 과정**: 
+  * **No-Offset 쿼리 튜닝**: 마지막으로 조회한 데이터의 PK를 기준점(Cursor)으로 사용하는 페이지네이션을 도입. `WHERE id < :cursor ORDER BY id DESC LIMIT 10` 형태로 쿼리를 개선하여 $O(1)$ 수준의 조회 성능을 확보했습니다.
+  * **클라이언트 친화적 응답 설계**: 프론트엔드 구현을 돕기 위해 응답 DTO에 `nextCursor`와 `hasNext` 필드를 추가. 실제 요청 사이즈보다 1개를 더 조회(11개)하는 로직으로 불필요한 DB Count 쿼리 호출을 방지했습니다.
+* **결과**: 데이터 증가에도 일정한 응답 속도를 보장하며, 데이터 변동 상황에서도 중복 없는 매끄러운 UX를 제공하게 되었습니다.
+
+### 2. 인프라 아키텍처 고도화: 전 구간 HTTPS 통신 구축 및 보안 쿠키 정책 수립
+* **문제 상황**: 소셜 로그인 시 로컬(HTTPS)과 백엔드(HTTP) 간 프로토콜 불일치로 Mixed Content 에러가 발생. 또한 Refresh Token을 Body로 전달 시 XSS 공격 탈취 위험이 존재했습니다.
+* **해결 과정**:
+  * **AWS 기반 HTTPS 환경 구축**: Route 53 커스텀 도메인 + ACM 인증서 + ALB를 통해 브라우저부터 로드밸런서까지 안전한 HTTPS 암호화 통신(443)을 구현하고, 백엔드로는 HTTP(80)로 포워딩하는 아키텍처를 설계했습니다.
+  * **토큰 탈취 방지 쿠키 정책**: Refresh Token을 HTTP Response Cookie로 전면 수정. 스프링 시큐리티에 개입하여 `HttpOnly`, `Secure`, `SameSite=None` 속성을 정밀하게 부여했습니다.
+* **결과**: 도메인 간 프로토콜 불일치 및 CORS 문제를 근본적으로 해결하고, XSS/CSRF 공격을 사전 차단하는 높은 수준의 보안 아키텍처를 완성했습니다.
+
+### 3. 마이크로서비스 관점의 도메인 결합도 완화: 비정규화를 통한 데이터 무결성 확보
+* **문제 상황**: 오답 노트가 원본 퀴즈 엔티티의 ID만 FK로 참조하도록 설계했으나, 관리자가 퀴즈를 수정/삭제할 경우 유저의 과거 오답 기록까지 변형되거나 에러가 발생하는 강결합 문제가 발견되었습니다.
+* **해결 과정**:
+  * **스냅샷 패턴 및 비정규화 도입**: 유저가 퀴즈를 채점하는 시점에 원본 데이터(질문, 보기, 해설 등)를 `QuizInfo`라는 별도 모델로 추출(비정규화)했습니다.
+  * **데이터 격리**: 추출된 스냅샷 데이터를 오답 노트 도메인에 안전하게 저장하여 읽기 성능(조인 최소화)을 높이고, '학습 기록 보존'이라는 비즈니스 요구사항을 충족시켰습니다.
+* **결과**: 퀴즈와 오답 노트 도메인의 생명주기를 분리하여, 마스터 데이터 변동에도 유저의 개인 학습 기록 무결성이 100% 보장되는 견고한 시스템을 구축했습니다.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 <br>
 
 ## 🔗 Links & References
+* **🎯 [BiteLearn 서비스 직접 경험해보기 (서비스 배포 링크)](https://www.bitelearn.site)**
 * **🏠 [팀 노션 (Team Workspace)](https://www.notion.so/goormkdx/1-2eac0ff4ce31802681bbd64b9d7f8c0d)**
 * **📝 [API 명세서 (API Specification)](https://www.notion.so/goormkdx/API-2eac0ff4ce3181909832f4c10165b91b)**
 * **🚀 [배포 및 API 테스트 (Swagger UI)](https://bitelearn.site/swagger-ui/index.html)**

--- a/README.md
+++ b/README.md
@@ -1,30 +1,58 @@
 # 📚 BiteLearn Backend
 > 사회 초년생을 위한 부동산·금융·세무 마이크로 러닝 플랫폼, **BiteLearn**의 백엔드 리포지토리
 
-<br>
+<a href="https://www.bitelearn.site"><img src="https://img.shields.io/badge/🌐_BiteLearn_Service-배포_링크-5A58FF?style=for-the-badge" alt="Service Link" /></a>
 
-## 📑 목차 (Table of Contents)
-- [🔗 Links & References](#-links--references)
-- [👥 Team & Collaboration](#-team--collaboration)
-- [🛠️ Tech Stack](#️-tech-stack)
-- [🛠️ Tech Stack](#️-tech-stack)
-- [🗄️ Database Modeling](#️-database-modeling)
-- [🏗️ System Architecture](#️-system-architecture)
-- [📁 Package Structure](#-package-structure)
-- [✨ Core Features](#-core-features)
-- [🔥 Troubleshooting](#-troubleshooting)
+<img width="700" alt="image" src="https://github.com/user-attachments/assets/b9b1f28a-5c93-4a65-a4f7-a2e6087b36fe" />
 
-<br>
+<br></br>
 
-## 🔗 Links & References
-* **🎯 [BiteLearn 서비스 직접 경험해보기 (서비스 배포 링크)](https://www.bitelearn.site)**
-* **🏠 [팀 노션 (Team Workspace)](https://www.notion.so/goormkdx/1-2eac0ff4ce31802681bbd64b9d7f8c0d)**
-* **📝 [API 명세서 (API Specification)](https://www.notion.so/goormkdx/API-2eac0ff4ce3181909832f4c10165b91b)**
-* **🚀 [배포 및 API 테스트 (Swagger UI)](https://bitelearn.site/swagger-ui/index.html)**
+## 📑 목차
+- [🔗 관련 링크 및 레퍼런스](#-관련-링크-및-레퍼런스)
+- [👥 팀 및 협업](#-팀-및-협업)
+- [🛠️ 기술 스택](#️-기술-스택)
+- [🗄️ 데이터베이스 모델링](#️-데이터베이스-모델링)
+- [🏗️ 시스템 아키텍처](#️-시스템-아키텍처)
+- [📁 패키지 구조](#-패키지-구조)
+- [✨ 핵심 기능](#-핵심-기능)
+- [🔥 트러블슈팅](#-트러블슈팅)
+- [🚀 성능 개선 및 튜닝](#-성능-개선-및-튜닝)
 
 <br>
 
-## 👥 Team & Collaboration
+## 🔗 관련 링크 및 레퍼런스
+<table>
+  <tr>
+    <td align="center" width="120">
+      <a href="https://www.notion.so/goormkdx/1-2eac0ff4ce31802681bbd64b9d7f8c0d"><img src="https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png" width="50" alt="Notion Icon"></a>
+    </td>
+    <td width="800">
+      <b><a href="https://www.notion.so/goormkdx/1-2eac0ff4ce31802681bbd64b9d7f8c0d">🏠 팀 노션 (Team Workspace)</a></b><br>
+      기획, 디자인, 프론트/백엔드의 협업 기록과 회의록 확인
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="120">
+      <a href="https://www.notion.so/goormkdx/API-2eac0ff4ce3181909832f4c10165b91b"><img src="https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png" width="50" alt="API Specs Icon"></a>
+    </td>
+    <td width="800">
+      <b><a href="https://www.notion.so/goormkdx/API-2eac0ff4ce3181909832f4c10165b91b">📝 API 명세서 (API Specification)</a></b><br>
+      프론트엔드 개발자와의 원활한 협업을 위해 작성한 API 요청 및 응답 명세서
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="120">
+      <a href="https://bitelearn.site/swagger-ui/index.html"><img src="https://upload.wikimedia.org/wikipedia/commons/a/ab/Swagger-logo.png" width="60" alt="Swagger Icon"></a>
+    </td>
+    <td width="800">
+      <b><a href="https://bitelearn.site/swagger-ui/index.html">🚀 배포 및 API 테스트 (Swagger UI)</a></b><br>
+      백엔드 서버에 직접 요청을 보내고 응답을 확인할 수 있는 API 명세 및 테스트 환경
+    </td>
+  </tr>
+</table>
+<br>
+
+## 👥 팀 및 협업
 > 기획, 디자인, 프론트엔드, 백엔드가 긴밀하게 소통하며 애자일(Agile)하게 개발한 **협업 프로젝트**입니다.<br>
 > 단독 백엔드 개발자로서 시스템 아키텍처 설계부터 인프라 배포, API 개발까지 전 과정을 책임지고 수행했습니다.
 
@@ -37,7 +65,7 @@
 
 <br>
 
-## 🛠️ Tech Stack
+## 🛠️ 기술 스택
 
 ### Backend
 * **Java 17 & Spring Boot 3.x** : 객체지향적 설계 및 풍부한 생태계를 활용한 안정적인 비즈니스 로직 구현
@@ -59,7 +87,7 @@
 
 <br>
 
-## 🗄️ Database Modeling
+## 🗄️ 데이터베이스 모델링
 
 <img width="500" alt="bitelearn ERD Diagram" src="https://github.com/user-attachments/assets/d066d290-f130-4260-8813-f752f26880df" />
 
@@ -76,7 +104,7 @@
 
 <br>
 
-## 🏗️ System Architecture
+## 🏗️ 시스템 아키텍처
 
 <img width="700" alt="bitelearn 시스템 아키텍처 diagram" src="https://github.com/user-attachments/assets/1c0f455c-0342-44ef-87a1-e2ec329ebc46" />
 
@@ -89,7 +117,7 @@
 
 <br>
 
-## 📁 Package Structure
+## 📁 패키지 구조
 
 ```text
 src/main/java/com/ogi1t/bitelearn
@@ -113,7 +141,7 @@ src/main/java/com/ogi1t/bitelearn
 
 <br>
 
-## ✨ Core Features
+## ✨ 핵심 기능
 
 ### 1. 회원 및 보안 시스템 (Auth & Security)
 * **통합 로그인 시스템**: 자체(Local) 회원가입 및 소셜 로그인(Google, Naver OAuth 2.0) 통합 구현
@@ -137,21 +165,21 @@ src/main/java/com/ogi1t/bitelearn
 
 <br>
 
-## 🔥 Troubleshooting
+## 🔥 트러블슈팅
 
-### 1. 대용량 데이터를 고려한 커서 기반 페이지네이션 및 무한 스크롤 API 설계
-* **문제 상황**: 초기 오답 노트 목록 API는 오프셋(Offset) 방식으로 설계되어, 페이지가 뒤로 갈수록 성능 저하($O(N)$ 시간 복잡도)와 실시간 데이터 변동 시 정합성 문제(중복 노출/누락)가 우려되었습니다.
-* **해결 과정**: 
-  * **No-Offset 쿼리 튜닝**: 마지막으로 조회한 데이터의 PK를 기준점(Cursor)으로 사용하는 페이지네이션을 도입. `WHERE id < :cursor ORDER BY id DESC LIMIT 10` 형태로 쿼리를 개선하여 $O(1)$ 수준의 조회 성능을 확보했습니다.
-  * **클라이언트 친화적 응답 설계**: 프론트엔드 구현을 돕기 위해 응답 DTO에 `nextCursor`와 `hasNext` 필드를 추가. 실제 요청 사이즈보다 1개를 더 조회(11개)하는 로직으로 불필요한 DB Count 쿼리 호출을 방지했습니다.
-* **결과**: 데이터 증가에도 일정한 응답 속도를 보장하며, 데이터 변동 상황에서도 중복 없는 매끄러운 UX를 제공하게 되었습니다.
-
-### 2. 인프라 아키텍처 고도화: 전 구간 HTTPS 통신 구축 및 보안 쿠키 정책 수립
+### 1. 인프라 아키텍처 고도화: 전 구간 HTTPS 통신 구축 및 보안 쿠키 정책 수립
 * **문제 상황**: 소셜 로그인 시 로컬(HTTPS)과 백엔드(HTTP) 간 프로토콜 불일치로 Mixed Content 에러가 발생. 또한 Refresh Token을 Body로 전달 시 XSS 공격 탈취 위험이 존재했습니다.
 * **해결 과정**:
   * **AWS 기반 HTTPS 환경 구축**: Route 53 커스텀 도메인 + ACM 인증서 + ALB를 통해 브라우저부터 로드밸런서까지 안전한 HTTPS 암호화 통신(443)을 구현하고, 백엔드로는 HTTP(80)로 포워딩하는 아키텍처를 설계했습니다.
   * **토큰 탈취 방지 쿠키 정책**: Refresh Token을 HTTP Response Cookie로 전면 수정. 스프링 시큐리티에 개입하여 `HttpOnly`, `Secure`, `SameSite=None` 속성을 정밀하게 부여했습니다.
 * **결과**: 도메인 간 프로토콜 불일치 및 CORS 문제를 근본적으로 해결하고, XSS/CSRF 공격을 사전 차단하는 높은 수준의 보안 아키텍처를 완성했습니다.
+
+### 2. 대용량 데이터를 고려한 커서 기반 페이지네이션 및 무한 스크롤 API 설계
+* **문제 상황**: 초기 오답 노트 목록 API는 오프셋(Offset) 방식으로 설계되어, 페이지가 뒤로 갈수록 성능 저하($O(N)$ 시간 복잡도)와 실시간 데이터 변동 시 정합성 문제(중복 노출/누락)가 우려되었습니다.
+* **해결 과정**: 
+  * **No-Offset 쿼리 튜닝**: 마지막으로 조회한 데이터의 PK를 기준점(Cursor)으로 사용하는 페이지네이션을 도입. `WHERE id < :cursor ORDER BY id DESC LIMIT 10` 형태로 쿼리를 개선하여 $O(1)$ 수준의 조회 성능을 확보했습니다.
+  * **클라이언트 친화적 응답 설계**: 프론트엔드 구현을 돕기 위해 응답 DTO에 `nextCursor`와 `hasNext` 필드를 추가. 실제 요청 사이즈보다 1개를 더 조회(11개)하는 로직으로 불필요한 DB Count 쿼리 호출을 방지했습니다.
+* **결과**: 데이터 증가에도 일정한 응답 속도를 보장하며, 데이터 변동 상황에서도 중복 없는 매끄러운 UX를 제공하게 되었습니다.
 
 ### 3. 마이크로서비스 관점의 도메인 결합도 완화: 비정규화를 통한 데이터 무결성 확보
 * **문제 상황**: 오답 노트가 원본 퀴즈 엔티티의 ID만 FK로 참조하도록 설계했으나, 관리자가 퀴즈를 수정/삭제할 경우 유저의 과거 오답 기록까지 변형되거나 에러가 발생하는 강결합 문제가 발견되었습니다.
@@ -159,3 +187,33 @@ src/main/java/com/ogi1t/bitelearn
   * **스냅샷 패턴 및 비정규화 도입**: 유저가 퀴즈를 채점하는 시점에 원본 데이터(질문, 보기, 해설 등)를 `QuizInfo`라는 별도 모델로 추출(비정규화)했습니다.
   * **데이터 격리**: 추출된 스냅샷 데이터를 오답 노트 도메인에 안전하게 저장하여 읽기 성능(조인 최소화)을 높이고, '학습 기록 보존'이라는 비즈니스 요구사항을 충족시켰습니다.
 * **결과**: 퀴즈와 오답 노트 도메인의 생명주기를 분리하여, 마스터 데이터 변동에도 유저의 개인 학습 기록 무결성이 100% 보장되는 견고한 시스템을 구축했습니다.
+
+<br>
+
+## 🚀 성능 개선 및 튜닝
+
+### 대규모 트래픽 대비 오답 노트 무한 스크롤 조회 성능 79% 개선 (0.5초 ➡️ 0.07초)
+* **문제 상황 (병목 발견):** 오답 노트 목록 조회 API에 커서 기반(No-Offset) 페이지네이션을 적용하여 N+1 문제를 방어했음에도 불구, JMeter 부하 테스트(Users: 100명) 결과 최대 응답 시간이 665ms까지 치솟으며 프리티어 EC2의 CPU 사용률이 95%에 달하는 병목 현상이 발생했습니다.
+* **원인 분석 (진짜 범인 찾기):**
+  1. **DB Full Scan:** MySQL이 `is_correct = false`인 조건과 `id < cursor` 조건을 찾기 위해 수만 건의 데이터를 풀스캔(Full Scan)하며 정렬까지 수행하고 있었습니다.
+  2. **커넥션 풀(HikariCP) 대기:** 풀스캔으로 인해 단일 쿼리 처리 시간이 길어지면서, 기본 설정인 10개의 DB 커넥션이 모두 고갈되었습니다. 이로 인해 후속 190여 개의 요청들이 커넥션을 얻기 위해 대기(Acquisition Time)하면서 전체 응답 시간이 기하급수적으로 늘어난 것이었습니다.
+* **해결 과정 (DB 인덱스 튜닝 및 부하 테스트 검증):**
+  * **복합 인덱스(Composite Index) 추가:** `UserQuizAnswer` 엔티티에 유저 ID, 오답 여부, 그리고 페이징 정렬을 위한 ID를 묶은 복합 인덱스(`idx_user_correct_id`)를 설계하여 적용했습니다.
+    ```java
+    @Table(name = "user_quiz_answer", indexes = {
+        @Index(name = "idx_user_correct_id", columnList = "user_id, is_correct, id DESC")
+    })
+    ```
+  * **불필요한 Count 쿼리 제거 (Service 단 최적화):** 첫 페이지 로딩 시에만 전체 카운트를 계산하고, 스크롤(두 번째 페이지)부터는 카운트 쿼리(`countByUserIdAndIsCorrectFalse`) 호출을 생략하도록 로직을 개선하여 불필요한 DB I/O를 차단했습니다.
+  * **JVM 웜업(Warm-up) 및 인덱스의 역설 인지:** 초기 테스트 시 캐시가 적재되지 않은 콜드 스타트(Cold Start) 상태이거나 데이터 모수가 적을 때 오히려 성능이 저하되는 현상을 발견했습니다. 이를 통제하기 위해 Before/After 각각 2회 이상의 반복 부하 테스트를 진행하여 객관적인 지표를 확보했습니다.
+* ✅ **결과 (지표 개선):**
+  * **CPU Usage:** 0.907 ➡️ **0.455 (약 50% 감소)**
+  * **Response Time:** 342ms ➡️ **70.9ms (약 79% 단축)**
+  결과적으로 인덱스 탐색(Index Seek)을 통해 쿼리 실행 계획을 최적화하고, 커넥션 풀의 병목을 완벽하게 해소하여 시스템 처리량(Throughput)을 극대화했습니다.
+
+<br>
+
+<img width="1572" height="623" alt="부하테스트 결과 캡처본_01" src="https://github.com/user-attachments/assets/e9be97e5-1a07-476f-93cb-946dbee397d4" />
+<img width="1583" height="622" alt="부하테스트 결과 캡처본_02" src="https://github.com/user-attachments/assets/69ea2a7a-8736-47fb-b432-b39ac1c134bc" />
+<img width="1577" height="569" alt="부하테스트 결과 캡처본_03" src="https://github.com/user-attachments/assets/25f3cfd9-8ba2-4605-bb21-89136826a47b" />
+<img width="1575" height="564" alt="부하테스트 결과 캡처본_04" src="https://github.com/user-attachments/assets/6eaacf32-7e5b-4dec-af0c-b5e97e54ed97" />

--- a/README.md
+++ b/README.md
@@ -4,12 +4,35 @@
 <br>
 
 ## 📑 목차 (Table of Contents)
+- [🔗 Links & References](#-links--references)
+- [👥 Team & Collaboration](#-team--collaboration)
+- [🛠️ Tech Stack](#️-tech-stack)
 - [🛠️ Tech Stack](#️-tech-stack)
 - [🗄️ Database Modeling](#️-database-modeling)
 - [🏗️ System Architecture](#️-system-architecture)
 - [📁 Package Structure](#-package-structure)
 - [✨ Core Features](#-core-features)
 - [🔥 Troubleshooting](#-troubleshooting)
+
+<br>
+
+## 🔗 Links & References
+* **🏠 [팀 노션 (Team Workspace)](https://www.notion.so/goormkdx/1-2eac0ff4ce31802681bbd64b9d7f8c0d)**
+* **📝 [API 명세서 (API Specification)](https://www.notion.so/goormkdx/API-2eac0ff4ce3181909832f4c10165b91b)**
+* **🚀 [배포 및 API 테스트 (Swagger UI)](https://bitelearn.site/swagger-ui/index.html)**
+
+<br>
+
+## 👥 Team & Collaboration
+> 기획, 디자인, 프론트엔드, 백엔드가 긴밀하게 소통하며 애자일(Agile)하게 개발한 **협업 프로젝트**입니다.<br>
+> 단독 백엔드 개발자로서 시스템 아키텍처 설계부터 인프라 배포, API 개발까지 전 과정을 책임지고 수행했습니다.
+
+| 역할 (Role) | 인원 | 멤버 이름 |
+| :--- | :---: | :--- |
+| **👑 PM (Product Manager)** | 3명 | 이성민, 장세혁, 한보름 |
+| **🎨 PD (Product Designer)** | 2명 | 박시원, 은석기 |
+| **💻 FE (Front-End)** | 1명 | 최아로인 |
+| **⚙️ BE (Back-End)** | 1명 | 백유정 |
 
 <br>
 
@@ -33,7 +56,7 @@
 * **OAuth 2.0 (Google, Naver)** : 사용자 가입 이탈률 최소화 및 민감 정보 보안 리스크 외부 위임
 * **보안 최적화** : Refresh Token에 `HttpOnly`, `Secure`, `SameSite=None` 쿠키 정책을 적용하여 XSS 및 CSRF 공격 원천 방어
 
----
+<br>
 
 ## 🗄️ Database Modeling
 
@@ -50,7 +73,7 @@
 4. **Stateless 아키텍처를 보완하는 토큰 관리 (`refresh_tokens`)**
    JWT 탈취 위험 방지 및 안전한 유효기간 관리를 위해 `refresh_tokens` 테이블을 설계하고 만료 시간(`expiredAt`)을 저장하여, 서버 단에서 세션을 주도적으로 제어할 수 있는 보안 토대를 마련했습니다.
 
----
+<br>
 
 ## 🏗️ System Architecture
 
@@ -63,7 +86,7 @@
 3. **AWS S3 연동을 통한 Stateless 서버 지향**: 퀴즈 및 단어장에 사용되는 미디어 이미지 파일들을 EC2 내부에 저장하지 않고 S3로 분리하여 서버의 디스크 I/O 부하를 줄이고 Scale-out 제약 사항을 해소했습니다.
 4. **Jenkins & Docker 기반 CI/CD 파이프라인**: GitHub에 코드가 Push 되면 Webhook을 통해 Jenkins가 빌드를 트리거하고, Docker 이미지로 패키징하여 배포까지 원클릭으로 이어지는 견고한 자동화를 구축했습니다.
 
----
+<br>
 
 ## 📁 Package Structure
 
@@ -87,7 +110,7 @@ src/main/java/com/ogi1t/bitelearn
         └── dto                 # Request/Response 및 Validation(@Valid) 객체
 ```
 
----
+<br>
 
 ## ✨ Core Features
 
@@ -111,7 +134,7 @@ src/main/java/com/ogi1t/bitelearn
 * **이어하기 기능**: 마이페이지에서 가장 최근 학습 챕터와 진행률(%)을 계산하여 즉시 이어갈 수 있는 동적 데이터 응답
 * **보상 및 레벨 시스템**: 학습 완료 시 자체 재화 '바이트(Bytes)' 적립 및 누적 바이트 기반 자동 레벨 산정 로직 구현
 
----
+<br>
 
 ## 🔥 Troubleshooting
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,19 +25,48 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // OAuth2 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    // DB
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11'
+
+    // JWT 라이브러리
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Lang3 랜덤 라이브러리 추가
+    implementation 'org.apache.commons:commons-lang3:3.20.0'
+
+    // Redis 의존성 추가
+    //implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // Redisson (분산 락 등을 위해 사용)
+    //implementation 'org.redisson:redisson:3.27.0'
+    // Jackson 라이브러리가 jSON으로 변환
+    implementation 'com.fasterxml.jackson.core:jackson-databind' // 핵심 도구
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310' // 날짜 처리용
+
+    // 테스트
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.assertj:assertj-core'  // 더 편한 assertion
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.assertj:assertj-core'  // 더 편한 assertion
+
+    // 성능
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ogi1t/bitelearn/BitelearnApplication.java
+++ b/src/main/java/com/ogi1t/bitelearn/BitelearnApplication.java
@@ -2,12 +2,21 @@ package com.ogi1t.bitelearn;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableJpaAuditing
+@EnableScheduling
 public class BitelearnApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BitelearnApplication.class, args);
-	}
-
+  public static void main(String[] args) {
+    SpringApplication.run(BitelearnApplication.class, args);
+    System.out.println("\n" +
+        "=================================================\n" +
+        "👮🚨🏃🏽‍➡️ Bitelearn Application 시작 완료!\n" +
+        "=================================================\n" +
+        "📋 Swagger UI: http://localhost:8080/swagger-ui/index.html\n" +
+        "=================================================\n");
+  }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.ogi1t.bitelearn.domain.auth.dto.request.LoginRequest;
 import com.ogi1t.bitelearn.domain.auth.dto.request.SignupRequest;
 import com.ogi1t.bitelearn.domain.auth.dto.response.TokenResponse;
 import com.ogi1t.bitelearn.domain.auth.service.AuthService;
+import com.ogi1t.bitelearn.global.exception.BusinessException;
+import com.ogi1t.bitelearn.global.exception.domain.AuthErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
@@ -50,15 +52,14 @@ public class AuthController {
       @CookieValue(name = "refreshToken", required = false) String refreshToken,
       HttpServletResponse response) {
 
-    if (refreshToken == null) {
-      throw new IllegalArgumentException("Refresh Token이 없습니다."); // 적절한 BusinessException으로 변경
+    // 1. 쿠키 자체가 없는 비회원일 경우
+    if (refreshToken == null || refreshToken.isEmpty()) {
+      throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
     }
 
-    TokenResponse tokenResponse = authService.refresh(refreshToken); // DTO 대신 String을 바로 넘김
+    TokenResponse tokenResponse = authService.refresh(refreshToken);
 
-    // 재발급된 Refresh Token으로 쿠키 갱신
     setRefreshTokenCookie(response, tokenResponse.getRefreshToken(), 14 * 24 * 60 * 60);
-
     return ResponseEntity.ok(tokenResponse);
   }
 
@@ -83,8 +84,8 @@ public class AuthController {
     ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
         .maxAge(maxAge)
         .path("/")
-        .secure(false) // HTTPS일 경우 true
-        .sameSite("Lax")
+        .secure(true) // HTTPS 이므로 true
+        .sameSite("None") // HTTPS 이므로 None 설정 가능
         .httpOnly(true)
         .build();
     response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/controller/AuthController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Auth API", description = "인증 API")
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/controller/AuthController.java
@@ -2,14 +2,17 @@ package com.ogi1t.bitelearn.domain.auth.controller;
 
 import com.ogi1t.bitelearn.domain.auth.dto.request.LoginRequest;
 import com.ogi1t.bitelearn.domain.auth.dto.request.SignupRequest;
-import com.ogi1t.bitelearn.domain.auth.dto.request.TokenRefreshRequest;
 import com.ogi1t.bitelearn.domain.auth.dto.response.TokenResponse;
 import com.ogi1t.bitelearn.domain.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,23 +35,58 @@ public class AuthController {
 
   @Operation(summary = "로컬 로그인")
   @PostMapping("/login")
-  public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request) {
-    TokenResponse response = authService.login(request);
-    return ResponseEntity.ok(response);
+  public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request, HttpServletResponse response) {
+    TokenResponse tokenResponse = authService.login(request);
+
+    // 로컬 로그인 시에도 Refresh Token은 HttpOnly 쿠키로 굽기
+    setRefreshTokenCookie(response, tokenResponse.getRefreshToken(), 14 * 24 * 60 * 60);
+
+    return ResponseEntity.ok(tokenResponse);
   }
 
   @Operation(summary = "토큰 재발급")
   @PostMapping("/refresh")
-  public ResponseEntity<TokenResponse> refresh(@RequestBody TokenRefreshRequest request) {
-    TokenResponse response = authService.refresh(request);
-    return ResponseEntity.ok(response);
+  public ResponseEntity<TokenResponse> refresh(
+      @CookieValue(name = "refreshToken", required = false) String refreshToken,
+      HttpServletResponse response) {
+
+    if (refreshToken == null) {
+      throw new IllegalArgumentException("Refresh Token이 없습니다."); // 적절한 BusinessException으로 변경
+    }
+
+    TokenResponse tokenResponse = authService.refresh(refreshToken); // DTO 대신 String을 바로 넘김
+
+    // 재발급된 Refresh Token으로 쿠키 갱신
+    setRefreshTokenCookie(response, tokenResponse.getRefreshToken(), 14 * 24 * 60 * 60);
+
+    return ResponseEntity.ok(tokenResponse);
   }
 
   @Operation(summary = "로그아웃")
   @PostMapping("/logout")
-  public ResponseEntity<String> logout(@RequestBody TokenRefreshRequest request) {
-    // 로그아웃 시 Refresh Token을 받아서 DB에서 지움
-    authService.logout(request.getRefreshToken());
+  public ResponseEntity<String> logout(
+      @CookieValue(name = "refreshToken", required = false) String refreshToken,
+      HttpServletResponse response) {
+
+    if (refreshToken != null) {
+      authService.logout(refreshToken);
+    }
+
+    // 쿠키 무효화 (만료시간 0)
+    setRefreshTokenCookie(response, "", 0);
+
     return ResponseEntity.ok("로그아웃 되었습니다.");
+  }
+
+  // 쿠키 생성 공통 메서드
+  private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken, long maxAge) {
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        .maxAge(maxAge)
+        .path("/")
+        .secure(false) // HTTPS일 경우 true
+        .sameSite("Lax")
+        .httpOnly(true)
+        .build();
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/controller/AuthController.java
@@ -1,0 +1,54 @@
+package com.ogi1t.bitelearn.domain.auth.controller;
+
+import com.ogi1t.bitelearn.domain.auth.dto.request.LoginRequest;
+import com.ogi1t.bitelearn.domain.auth.dto.request.SignupRequest;
+import com.ogi1t.bitelearn.domain.auth.dto.request.TokenRefreshRequest;
+import com.ogi1t.bitelearn.domain.auth.dto.response.TokenResponse;
+import com.ogi1t.bitelearn.domain.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth API", description = "인증 API")
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+  private final AuthService authService;
+
+  @Operation(summary = "로컬 회원가입")
+  @PostMapping("/signup")
+  public ResponseEntity<String> signup(@RequestBody @Valid SignupRequest request) {
+    authService.signup(request);
+    return ResponseEntity.ok("회원가입이 완료되었습니다.");
+  }
+
+  @Operation(summary = "로컬 로그인")
+  @PostMapping("/login")
+  public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request) {
+    TokenResponse response = authService.login(request);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "토큰 재발급")
+  @PostMapping("/refresh")
+  public ResponseEntity<TokenResponse> refresh(@RequestBody TokenRefreshRequest request) {
+    TokenResponse response = authService.refresh(request);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "로그아웃")
+  @PostMapping("/logout")
+  public ResponseEntity<String> logout(@RequestBody TokenRefreshRequest request) {
+    // 로그아웃 시 Refresh Token을 받아서 DB에서 지움
+    authService.logout(request.getRefreshToken());
+    return ResponseEntity.ok("로그아웃 되었습니다.");
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/info/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/info/GoogleOAuth2UserInfo.java
@@ -1,0 +1,37 @@
+package com.ogi1t.bitelearn.domain.auth.dto.info;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo implements OAuth2UserInfo {
+
+  private final Map<String, Object> attributes;
+
+  public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+    this.attributes = attributes;
+  }
+
+  @Override
+  public String getProviderId() {
+    return (String) attributes.get("sub");
+  }
+
+  @Override
+  public String getProvider() {
+    return "google";
+  }
+
+  @Override
+  public String getEmail() {
+    return (String) attributes.get("email");
+  }
+
+  @Override
+  public String getName() {
+    return (String) attributes.get("name");
+  }
+
+  @Override
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/info/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/info/NaverOAuth2UserInfo.java
@@ -1,0 +1,40 @@
+package com.ogi1t.bitelearn.domain.auth.dto.info;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo implements OAuth2UserInfo {
+
+  private final Map<String, Object> attributes; // 전체 데이터
+  private final Map<String, Object> response;   // response 내부 데이터
+
+  public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+    this.attributes = attributes;
+    // 네이버는 "response" 키 안에 유저 정보가 들어있음
+    this.response = (Map<String, Object>) attributes.get("response");
+  }
+
+  @Override
+  public String getProviderId() {
+    return (String) response.get("id");
+  }
+
+  @Override
+  public String getProvider() {
+    return "naver";
+  }
+
+  @Override
+  public String getEmail() {
+    return (String) response.get("email");
+  }
+
+  @Override
+  public String getName() {
+    return (String) response.get("name");
+  }
+
+  @Override
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/info/OAuth2UserInfo.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/info/OAuth2UserInfo.java
@@ -1,0 +1,11 @@
+package com.ogi1t.bitelearn.domain.auth.dto.info;
+
+import java.util.Map;
+
+public interface OAuth2UserInfo {
+  String getProviderId(); // 소셜 식별자 (google의 sub 등)
+  String getProvider();   // google, kakao, naver
+  String getEmail();
+  String getName();
+  Map<String, Object> getAttributes();
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.ogi1t.bitelearn.domain.auth.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+
+  private String email;
+  private String password;
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/request/OAuthLoginRequest.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/request/OAuthLoginRequest.java
@@ -1,0 +1,13 @@
+package com.ogi1t.bitelearn.domain.auth.dto.request;
+
+import com.ogi1t.bitelearn.domain.auth.entity.enums.OAuthProvider;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OAuthLoginRequest {
+
+  private OAuthProvider provider; // NAVER, GOOGLE
+  private String authorizationCode; // OAuth 인가 코드
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/request/SignupRequest.java
@@ -1,0 +1,23 @@
+package com.ogi1t.bitelearn.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequest {
+
+  @NotBlank(message = "이메일은 필수 입력값입니다.")
+  @Email(message = "올바른 이메일 형식이 아닙니다.") // 이메일 형식 검증
+  private String email;
+
+  @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+  private String password;
+
+  @NotBlank(message = "닉네임은 필수 입력값입니다.")
+  @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,10}$", message = "닉네임은 특수문자 제외 2~10자리여야 합니다.") // 닉네임 형식 검증
+  private String nickname;
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/request/SignupRequest.java
@@ -15,6 +15,7 @@ public class SignupRequest {
   private String email;
 
   @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+  @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$", message = "비밀번호는 8~20자의 영문, 숫자, 특수문자 조합이어야 합니다.") // 비밀번호 형식 검증
   private String password;
 
   @NotBlank(message = "닉네임은 필수 입력값입니다.")

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/request/TokenRefreshRequest.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/request/TokenRefreshRequest.java
@@ -1,0 +1,12 @@
+package com.ogi1t.bitelearn.domain.auth.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// Access Token 재발급 요청 DTO
+@Getter
+@NoArgsConstructor
+public class TokenRefreshRequest {
+
+  private String refreshToken; // Refresh Token 값
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/response/TokenResponse.java
@@ -1,5 +1,6 @@
 package com.ogi1t.bitelearn.domain.auth.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +17,9 @@ public class TokenResponse {
 
   private String grantType;    // 보통 "Bearer"
   private String accessToken;  // JWT Access Token
+
+  @JsonIgnore // 응답 바디(JSON) 직렬화 시 이 필드를 제외시킨다!
   private String refreshToken; // JWT Refresh Token
+
   private Long accessTokenExpiresIn; // 액세스 토큰 만료 시간 (밀리초)
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,21 @@
+package com.ogi1t.bitelearn.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Access / Refresh Token 응답 DTO
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenResponse {
+
+  private String grantType;    // 보통 "Bearer"
+  private String accessToken;  // JWT Access Token
+  private String refreshToken; // JWT Refresh Token
+  private Long accessTokenExpiresIn; // 액세스 토큰 만료 시간 (밀리초)
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/entity/OAuthAccount.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/entity/OAuthAccount.java
@@ -1,0 +1,53 @@
+package com.ogi1t.bitelearn.domain.auth.entity;
+
+import com.ogi1t.bitelearn.domain.auth.entity.enums.OAuthProvider;
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 외부 OAuth 계정과 내부 User를 매핑
+@Entity
+@Table(
+    name = "oauth_accounts",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"provider", "providerId"})
+    }
+)
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OAuthAccount {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  private User user;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private OAuthProvider provider;
+
+  @Column(nullable = false, length = 100)
+  private String providerId;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,44 @@
+package com.ogi1t.bitelearn.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 로그인 세션 유지를 위한 Refresh Token
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long userId; // 토큰 소유자 식별용
+
+  @Column(nullable = false, length = 255)
+  private String token;
+
+  @Column(nullable = false)
+  private LocalDateTime expiredAt;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  public boolean isExpired(LocalDateTime now) {
+    return now.isAfter(expiredAt);
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/entity/enums/OAuthProvider.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/entity/enums/OAuthProvider.java
@@ -1,0 +1,6 @@
+package com.ogi1t.bitelearn.domain.auth.entity.enums;
+
+// 지원하는 OAuth 제공자 목록
+public enum OAuthProvider {
+  NAVER, GOOGLE
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/entity/enums/ProviderType.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/entity/enums/ProviderType.java
@@ -1,0 +1,7 @@
+package com.ogi1t.bitelearn.domain.auth.entity.enums;
+
+public enum ProviderType {
+    LOCAL,  // 일반 회원가입
+    GOOGLE,
+    NAVER
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/repository/OAuthAccountRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/repository/OAuthAccountRepository.java
@@ -1,0 +1,15 @@
+package com.ogi1t.bitelearn.domain.auth.repository;
+
+import com.ogi1t.bitelearn.domain.auth.entity.OAuthAccount;
+import com.ogi1t.bitelearn.domain.auth.entity.enums.OAuthProvider;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OAuthAccountRepository extends JpaRepository<OAuthAccount, Long> {
+
+  // provider + providerId로 OAuth 계정 조회
+  Optional<OAuthAccount> findByProviderAndProviderId(OAuthProvider provider, String providerId);
+
+  // 특정 유저가 연동한 OAuth 계정 목록 조회 (선택)
+  Optional<OAuthAccount> findByUserId(Long userId);
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package com.ogi1t.bitelearn.domain.auth.repository;
+
+import com.ogi1t.bitelearn.domain.auth.entity.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+  // refresh token 문자열로 조회 (재발급 시 사용)
+  Optional<RefreshToken> findByToken(String token);
+
+  // 특정 유저의 refresh token 조회 (로그아웃 / 재로그인 처리용)
+  Optional<RefreshToken> findByUserId(Long userId);
+
+  // 특정 유저의 refresh token 삭제
+  void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/repository/RefreshTokenRepository.java
@@ -3,6 +3,7 @@ package com.ogi1t.bitelearn.domain.auth.repository;
 import com.ogi1t.bitelearn.domain.auth.entity.RefreshToken;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
@@ -13,5 +14,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
   Optional<RefreshToken> findByUserId(Long userId);
 
   // 특정 유저의 refresh token 삭제
+  @Transactional
   void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/service/AuthService.java
@@ -1,0 +1,140 @@
+package com.ogi1t.bitelearn.domain.auth.service;
+
+import com.ogi1t.bitelearn.domain.auth.dto.request.LoginRequest;
+import com.ogi1t.bitelearn.domain.auth.dto.request.SignupRequest;
+import com.ogi1t.bitelearn.domain.auth.dto.request.TokenRefreshRequest;
+import com.ogi1t.bitelearn.domain.auth.dto.response.TokenResponse;
+import com.ogi1t.bitelearn.domain.auth.entity.RefreshToken;
+import com.ogi1t.bitelearn.domain.auth.entity.enums.ProviderType;
+import com.ogi1t.bitelearn.domain.auth.repository.RefreshTokenRepository;
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
+import com.ogi1t.bitelearn.global.exception.BusinessException;
+import com.ogi1t.bitelearn.global.exception.domain.AuthErrorCode;
+import com.ogi1t.bitelearn.global.exception.domain.UserErrorCode;
+import com.ogi1t.bitelearn.global.security.JwtProvider;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final UserRepository userRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final JwtProvider jwtProvider;
+  private final PasswordEncoder passwordEncoder;
+
+  // 1. 로컬 회원가입
+  @Transactional
+  public void signup(SignupRequest request) {
+    // 이메일 중복 검사
+    if (userRepository.existsByEmail(request.getEmail())) {
+      throw new BusinessException(AuthErrorCode.EMAIL_DUPLICATION);
+    }
+
+    // 닉네임 중복 검사
+    if (userRepository.existsByNickname(request.getNickname())) {
+      throw new BusinessException(UserErrorCode.NICKNAME_DUPLICATION);
+    }
+
+    if (userRepository.existsByEmail(request.getEmail())) {
+      throw new BusinessException(AuthErrorCode.EMAIL_DUPLICATION);
+    }
+
+    User user = User.builder()
+        .email(request.getEmail())
+        .password(passwordEncoder.encode(request.getPassword()))
+        .nickname(request.getNickname())
+        .providerType(ProviderType.LOCAL)
+        .build();
+
+    userRepository.save(user);
+  }
+
+  // 2. 로컬 로그인
+  @Transactional
+  public TokenResponse login(LoginRequest request) {
+    User user = userRepository.findByEmail(request.getEmail())
+        .orElseThrow(() -> new BusinessException(AuthErrorCode.LOGIN_FAILED));
+
+    if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+      throw new BusinessException(AuthErrorCode.LOGIN_FAILED);
+    }
+
+    String accessToken = jwtProvider.createAccessToken(
+        user.getId(),
+        user.getEmail(),
+        user.getNickname(),
+        user.getProviderType()
+    );
+    String refreshToken = jwtProvider.createRefreshToken(user.getId());
+
+    refreshTokenRepository.deleteByUserId(user.getId());
+    refreshTokenRepository.save(RefreshToken.builder()
+        .userId(user.getId())
+        .token(refreshToken)
+        .createdAt(LocalDateTime.now())
+        .expiredAt(LocalDateTime.now().plusDays(14))
+        .build());
+
+    return TokenResponse.builder()
+        .grantType("Bearer")
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .accessTokenExpiresIn(jwtProvider.getAccessTokenExpirationTime())
+        .build();
+  }
+
+  // 3. 토큰 재발급
+  @Transactional
+  public TokenResponse refresh(TokenRefreshRequest request) {
+    if (!jwtProvider.validateRefreshToken(request.getRefreshToken())) {
+      throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    RefreshToken storedToken = refreshTokenRepository.findByToken(request.getRefreshToken())
+        .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+    User user = userRepository.findById(storedToken.getUserId())
+        .orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));
+
+    String newAccessToken = jwtProvider.createAccessToken(
+        user.getId(),
+        user.getEmail(),
+        user.getNickname(),
+        user.getProviderType()
+    );
+    String newRefreshToken = jwtProvider.createRefreshToken(user.getId());
+
+    refreshTokenRepository.delete(storedToken);
+    refreshTokenRepository.save(RefreshToken.builder()
+        .userId(user.getId())
+        .token(newRefreshToken)
+        .createdAt(LocalDateTime.now())
+        .expiredAt(LocalDateTime.now().plusDays(14))
+        .build());
+
+    return TokenResponse.builder()
+        .grantType("Bearer")
+        .accessToken(newAccessToken)
+        .refreshToken(newRefreshToken)
+        .accessTokenExpiresIn(jwtProvider.getAccessTokenExpirationTime())
+        .build();
+  }
+
+  // 4. 로그아웃
+  @Transactional
+  public void logout(String refreshToken) {
+    // 리프레시 토큰을 DB에서 삭제하면 재발급이 불가능해지므로 로그아웃 처리됨
+    RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken)
+        .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+    refreshTokenRepository.delete(storedToken);
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/service/AuthService.java
@@ -93,16 +93,20 @@ public class AuthService {
   // 3. 토큰 재발급
   @Transactional
   public TokenResponse refresh(String refreshToken) {
-    if (!jwtProvider.validateRefreshToken(refreshToken)) {
-      throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
-    }
+    // 1. 검증 시도
+    // JwtProvider.validateRefreshToken 내부에서 BusinessException을 던지기 때문에
+    // 여기서 별도의 if문으로 throw를 던질 필요가 없습니다. (메서드 실행 자체가 검증임)
+    jwtProvider.validateRefreshToken(refreshToken);
 
+    // 2. DB에서 저장된 토큰인지 확인
     RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken)
         .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
 
+    // 3. 유저 존재 확인
     User user = userRepository.findById(storedToken.getUserId())
         .orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));
 
+    // 4. 새로운 토큰들 생성
     String newAccessToken = jwtProvider.createAccessToken(
         user.getId(),
         user.getEmail(),
@@ -111,6 +115,7 @@ public class AuthService {
     );
     String newRefreshToken = jwtProvider.createRefreshToken(user.getId());
 
+    // 5. 기존 토큰 삭제 후 새 토큰 저장
     refreshTokenRepository.delete(storedToken);
     refreshTokenRepository.save(RefreshToken.builder()
         .userId(user.getId())

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/service/AuthService.java
@@ -2,7 +2,6 @@ package com.ogi1t.bitelearn.domain.auth.service;
 
 import com.ogi1t.bitelearn.domain.auth.dto.request.LoginRequest;
 import com.ogi1t.bitelearn.domain.auth.dto.request.SignupRequest;
-import com.ogi1t.bitelearn.domain.auth.dto.request.TokenRefreshRequest;
 import com.ogi1t.bitelearn.domain.auth.dto.response.TokenResponse;
 import com.ogi1t.bitelearn.domain.auth.entity.RefreshToken;
 import com.ogi1t.bitelearn.domain.auth.entity.enums.ProviderType;
@@ -93,12 +92,12 @@ public class AuthService {
 
   // 3. 토큰 재발급
   @Transactional
-  public TokenResponse refresh(TokenRefreshRequest request) {
-    if (!jwtProvider.validateRefreshToken(request.getRefreshToken())) {
+  public TokenResponse refresh(String refreshToken) {
+    if (!jwtProvider.validateRefreshToken(refreshToken)) {
       throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
     }
 
-    RefreshToken storedToken = refreshTokenRepository.findByToken(request.getRefreshToken())
+    RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken)
         .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
 
     User user = userRepository.findById(storedToken.getUserId())

--- a/src/main/java/com/ogi1t/bitelearn/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,89 @@
+package com.ogi1t.bitelearn.domain.auth.service;
+
+import com.ogi1t.bitelearn.domain.auth.dto.info.GoogleOAuth2UserInfo;
+import com.ogi1t.bitelearn.domain.auth.dto.info.NaverOAuth2UserInfo;
+import com.ogi1t.bitelearn.domain.auth.dto.info.OAuth2UserInfo;
+import com.ogi1t.bitelearn.domain.auth.entity.OAuthAccount;
+import com.ogi1t.bitelearn.domain.auth.entity.enums.OAuthProvider;
+import com.ogi1t.bitelearn.domain.auth.entity.enums.ProviderType;
+import com.ogi1t.bitelearn.domain.auth.repository.OAuthAccountRepository;
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
+import com.ogi1t.bitelearn.global.security.CustomPrincipal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+  private final UserRepository userRepository;
+  private final OAuthAccountRepository oauthAccountRepository;
+
+  @Override
+  @Transactional
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    // 1. 소셜 서비스(구글 등)에서 유저 정보 가져오기
+    OAuth2User oAuth2User = super.loadUser(userRequest);
+
+    // 2. 어떤 소셜인지 확인 (google, naver, kakao)
+    String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+    OAuth2UserInfo oAuth2UserInfo = null;
+
+    if (registrationId.equals("google")) {
+      oAuth2UserInfo = new GoogleOAuth2UserInfo(oAuth2User.getAttributes());
+    } else if (registrationId.equals("naver")) {
+      oAuth2UserInfo = new NaverOAuth2UserInfo(oAuth2User.getAttributes());
+    } else {
+      log.error("지원하지 않는 소셜 로그인입니다. ID: {}", registrationId);
+      throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다.");
+    }
+
+    // 3. DB 저장 또는 업데이트
+    User user = saveOrUpdate(oAuth2UserInfo);
+
+    // 4. CustomPrincipal(통합 유저 객체) 반환 -> SecurityContext에 저장됨
+    return new CustomPrincipal(user, oAuth2User.getAttributes());
+  }
+
+  private User saveOrUpdate(OAuth2UserInfo userInfo) {
+    // OAuthAccount 테이블에서 먼저 조회 (provider + providerId)
+    OAuthProvider provider = OAuthProvider.valueOf(userInfo.getProvider().toUpperCase());
+
+    return oauthAccountRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
+        .map(OAuthAccount::getUser)
+        .orElseGet(() -> {
+          // 계정이 없으면 신규 생성
+          // 닉네임 중복 방지 로직 (간단 예시)
+          String nickname = userInfo.getName() + "_" + UUID.randomUUID().toString().substring(0, 5);
+
+          User newUser = User.builder()
+              .email(userInfo.getEmail())
+              .nickname(nickname)
+              .providerType(ProviderType.valueOf(userInfo.getProvider().toUpperCase()))
+              .createdAt(LocalDateTime.now())
+              .build();
+          userRepository.save(newUser);
+
+          OAuthAccount newAccount = OAuthAccount.builder()
+              .user(newUser)
+              .provider(provider)
+              .providerId(userInfo.getProviderId())
+              .createdAt(LocalDateTime.now())
+              .build();
+          oauthAccountRepository.save(newAccount);
+
+          return newUser;
+        });
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/dashboard/controller/DashboardController.java
@@ -1,0 +1,39 @@
+package com.ogi1t.bitelearn.domain.dashboard.controller;
+
+import com.ogi1t.bitelearn.domain.dashboard.dto.response.RecommendedChapterResponse;
+import com.ogi1t.bitelearn.domain.dashboard.service.DashboardService;
+import com.ogi1t.bitelearn.global.exception.BusinessException;
+import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
+import com.ogi1t.bitelearn.global.security.CustomPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Dashboard API", description = "대시보드(홈 화면) API")
+@RestController
+@RequestMapping("/dashboards")
+@RequiredArgsConstructor
+public class DashboardController {
+
+  private final DashboardService dashboardService;
+
+  @Operation(summary = "랜덤 학습 챕터 추천", description = "홈 화면에 노출될 랜덤 학습 챕터 2개를 추천합니다. 유저가 한 번도 학습하지 않은 완전히 새로운 토픽을 우선적으로 노출하여 학습의 다양성을 제공합니다.")
+  @GetMapping("/recommendations")
+  public ResponseEntity<List<RecommendedChapterResponse>> getRecommendations(
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    // 비회원 접근 차단 (유저의 기존 학습 기록을 기반으로 추천해야 하므로 로그인 필수)
+    if (principal == null) {
+      throw new BusinessException(LearningErrorCode.UNAUTHORIZED_ACCESS);
+    }
+
+    List<RecommendedChapterResponse> response = dashboardService.getRandomRecommendations(principal.getUserId());
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/dashboard/controller/DashboardController.java
@@ -3,7 +3,7 @@ package com.ogi1t.bitelearn.domain.dashboard.controller;
 import com.ogi1t.bitelearn.domain.dashboard.dto.response.RecommendedChapterResponse;
 import com.ogi1t.bitelearn.domain.dashboard.service.DashboardService;
 import com.ogi1t.bitelearn.global.exception.BusinessException;
-import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
+import com.ogi1t.bitelearn.global.exception.domain.DashboardErrorCode;
 import com.ogi1t.bitelearn.global.security.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,7 +30,7 @@ public class DashboardController {
 
     // 비회원 접근 차단 (유저의 기존 학습 기록을 기반으로 추천해야 하므로 로그인 필수)
     if (principal == null) {
-      throw new BusinessException(LearningErrorCode.UNAUTHORIZED_ACCESS);
+      throw new BusinessException(DashboardErrorCode.UNAUTHORIZED_ACCESS);
     }
 
     List<RecommendedChapterResponse> response = dashboardService.getRandomRecommendations(principal.getUserId());

--- a/src/main/java/com/ogi1t/bitelearn/domain/dashboard/dto/response/RecommendedChapterResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/dashboard/dto/response/RecommendedChapterResponse.java
@@ -1,0 +1,29 @@
+package com.ogi1t.bitelearn.domain.dashboard.dto.response;
+
+import com.ogi1t.bitelearn.domain.learning.entity.Chapter;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Topic;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RecommendedChapterResponse {
+  private Long chapterId;
+  private Category category;
+  private Topic topic;
+  private String title;
+  private String prologueSubtitle;
+  private Integer sequence;
+
+  public static RecommendedChapterResponse from(Chapter chapter) {
+    return RecommendedChapterResponse.builder()
+        .chapterId(chapter.getId())
+        .category(chapter.getCategory())
+        .topic(chapter.getTopic())
+        .title(chapter.getTitle())
+        .prologueSubtitle(chapter.getPrologueSubtitle())
+        .sequence(chapter.getSequence())
+        .build();
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/dashboard/service/DashboardService.java
@@ -1,0 +1,81 @@
+package com.ogi1t.bitelearn.domain.dashboard.service;
+
+import com.ogi1t.bitelearn.domain.dashboard.dto.response.RecommendedChapterResponse;
+import com.ogi1t.bitelearn.domain.learning.entity.Chapter;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Topic;
+import com.ogi1t.bitelearn.domain.learning.repository.ChapterRepository;
+import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DashboardService {
+
+  private final ChapterRepository chapterRepository;
+  private final UserQuizAnswerRepository answerRepository;
+
+  public List<RecommendedChapterResponse> getRandomRecommendations(Long userId) {
+    // 1. 유저가 시도한 챕터 ID 목록 조회
+    List<Long> attemptedChapterIds = answerRepository.findAttemptedChapterIdsByUserId(userId);
+
+    // 2. 전체 챕터 조회
+    List<Chapter> allChapters = chapterRepository.findAll();
+
+    // 3. 유저가 이미 건드린 '토픽' 목록 추출
+    Set<Topic> touchedTopics = allChapters.stream()
+        .filter(c -> attemptedChapterIds.contains(c.getId()))
+        .map(Chapter::getTopic)
+        .collect(Collectors.toSet());
+
+    // 4. 아직 풀지 않은 전체 챕터 필터링
+    List<Chapter> unattemptedChapters = allChapters.stream()
+        .filter(c -> !attemptedChapterIds.contains(c.getId()))
+        .collect(Collectors.toList());
+
+    // 5. '아예 안 건드린 토픽'과 '건드리긴 했지만 남은 챕터가 있는 토픽' 분리
+    List<Chapter> untouchedTopicChapters = unattemptedChapters.stream()
+        .filter(c -> !touchedTopics.contains(c.getTopic()))
+        .collect(Collectors.toList());
+
+    List<Chapter> touchedTopicChapters = unattemptedChapters.stream()
+        .filter(c -> touchedTopics.contains(c.getTopic()))
+        .collect(Collectors.toList());
+
+    // 6. 각 토픽별로 가장 앞 번호(sequence)의 챕터만 후보로 선정 후 섞기
+    List<Chapter> candidates = new ArrayList<>();
+    candidates.addAll(pickFirstChaptersAndShuffle(untouchedTopicChapters)); // 우선순위 1: 완전 새로운 토픽
+    candidates.addAll(pickFirstChaptersAndShuffle(touchedTopicChapters));   // 우선순위 2: 풀다 만 토픽
+
+    // 7. 상위 2개 추출하여 DTO 변환 (남은 챕터가 1개 이하면 있는 만큼만 반환)
+    return candidates.stream()
+        .limit(2)
+        .map(RecommendedChapterResponse::from)
+        .collect(Collectors.toList());
+  }
+
+  // 토픽별로 가장 순서가 빠른 챕터 1개씩만 뽑아서 랜덤으로 섞어주는 헬퍼 메서드
+  private List<Chapter> pickFirstChaptersAndShuffle(List<Chapter> chapters) {
+    Map<Topic, Optional<Chapter>> minSeqByTopic = chapters.stream()
+        .collect(Collectors.groupingBy(Chapter::getTopic,
+            Collectors.minBy(Comparator.comparing(Chapter::getSequence))));
+
+    List<Chapter> distinctChapters = minSeqByTopic.values().stream()
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toList());
+
+    Collections.shuffle(distinctChapters); // 랜덤 추천을 위한 셔플
+    return distinctChapters;
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/controller/LearningController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/controller/LearningController.java
@@ -8,13 +8,15 @@ import com.ogi1t.bitelearn.domain.learning.dto.response.QuizSubmitResponse;
 import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
 import com.ogi1t.bitelearn.domain.learning.entity.enums.Topic;
 import com.ogi1t.bitelearn.domain.learning.service.LearningService;
+import com.ogi1t.bitelearn.global.exception.BusinessException;
+import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
 import com.ogi1t.bitelearn.global.security.CustomPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
 
 @Tag(name = "Learning API", description = "학습 API")
 @RestController
@@ -24,38 +26,51 @@ public class LearningController {
 
   private final LearningService learningService;
 
-  // 1. 챕터 목록 조회 (Query Parameter 방식)
+  @Operation(summary = "챕터 목록 조회", description = "카테고리와 주제에 맞는 챕터 목록을 조회합니다. (비회원 접근 가능)")
   @GetMapping
   public ResponseEntity<ChapterListResponse> getChapters(
       @RequestParam Category category,
       @RequestParam Topic topic,
       @AuthenticationPrincipal CustomPrincipal principal) {
 
-    ChapterListResponse response = learningService.getChaptersByCategoryAndTopic(principal.getUserId(), category, topic);
+    // 비회원(null) 분기 처리
+    Long userId = (principal != null) ? principal.getUserId() : null;
+
+    ChapterListResponse response = learningService.getChaptersByCategoryAndTopic(userId, category, topic);
     return ResponseEntity.ok(response);
   }
 
-  // 2. 단일 챕터 학습 데이터(단어+퀴즈) 조회
+  @Operation(summary = "단일 챕터 학습 데이터 조회", description = "챕터 진입 시 단어장과 퀴즈(정답 제외) 데이터를 조회합니다.")
   @GetMapping("/{chapterId}")
   public ResponseEntity<ChapterLearningResponse> getChapterLearningData(
       @PathVariable Long chapterId,
       @AuthenticationPrincipal CustomPrincipal principal) {
 
+    // 비회원 접근 차단
+    if (principal == null) {
+      throw new BusinessException(LearningErrorCode.UNAUTHORIZED_ACCESS);
+    }
+
     ChapterLearningResponse response = learningService.getChapterLearningData(principal.getUserId(), chapterId);
     return ResponseEntity.ok(response);
   }
 
-  // 3. 단어장 완료 처리
+  @Operation(summary = "단어장 완료 처리", description = "단어장 학습을 마치고 퀴즈로 넘어갈 때 진행 상태를 업데이트합니다.")
   @PostMapping("/{chapterId}/vocab-complete")
   public ResponseEntity<Void> completeVocabulary(
       @PathVariable Long chapterId,
       @AuthenticationPrincipal CustomPrincipal principal) {
 
+    // 비회원 접근 차단
+    if (principal == null) {
+      throw new BusinessException(LearningErrorCode.UNAUTHORIZED_ACCESS);
+    }
+
     learningService.completeVocabulary(principal.getUserId(), chapterId);
     return ResponseEntity.ok().build();
   }
 
-  // 4. 퀴즈 1문제 제출 및 채점
+  @Operation(summary = "퀴즈 정답 제출 및 채점", description = "한 문제의 정답을 제출하고 채점 결과를 받습니다.")
   @PostMapping("/{chapterId}/quizzes/{quizId}")
   public ResponseEntity<QuizSubmitResponse> submitQuiz(
       @PathVariable Long chapterId,
@@ -63,15 +78,25 @@ public class LearningController {
       @RequestBody QuizSubmitRequest request,
       @AuthenticationPrincipal CustomPrincipal principal) {
 
+    // 비회원 접근 차단
+    if (principal == null) {
+      throw new BusinessException(LearningErrorCode.UNAUTHORIZED_ACCESS);
+    }
+
     QuizSubmitResponse response = learningService.submitQuizAnswer(principal.getUserId(), chapterId, quizId, request);
     return ResponseEntity.ok(response);
   }
 
-  // 5. 챕터 최종 결과 조회
+  @Operation(summary = "챕터 최종 결과 조회", description = "챕터 학습을 마친 후 정답률과 보상 결과를 조회합니다.")
   @GetMapping("/{chapterId}/result")
   public ResponseEntity<ChapterResultResponse> getChapterResult(
       @PathVariable Long chapterId,
       @AuthenticationPrincipal CustomPrincipal principal) {
+
+    // 비회원 접근 차단
+    if (principal == null) {
+      throw new BusinessException(LearningErrorCode.UNAUTHORIZED_ACCESS);
+    }
 
     ChapterResultResponse response = learningService.getChapterResult(principal.getUserId(), chapterId);
     return ResponseEntity.ok(response);

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/controller/LearningController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/controller/LearningController.java
@@ -1,0 +1,79 @@
+package com.ogi1t.bitelearn.domain.learning.controller;
+
+import com.ogi1t.bitelearn.domain.learning.dto.request.QuizSubmitRequest;
+import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterLearningResponse;
+import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterListResponse;
+import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterResultResponse;
+import com.ogi1t.bitelearn.domain.learning.dto.response.QuizSubmitResponse;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Topic;
+import com.ogi1t.bitelearn.domain.learning.service.LearningService;
+import com.ogi1t.bitelearn.global.security.CustomPrincipal;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+
+@Tag(name = "Learning API", description = "학습 API")
+@RestController
+@RequestMapping("/learning/chapters")
+@RequiredArgsConstructor
+public class LearningController {
+
+  private final LearningService learningService;
+
+  // 1. 챕터 목록 조회 (Query Parameter 방식)
+  @GetMapping
+  public ResponseEntity<ChapterListResponse> getChapters(
+      @RequestParam Category category,
+      @RequestParam Topic topic,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    ChapterListResponse response = learningService.getChaptersByCategoryAndTopic(principal.getUserId(), category, topic);
+    return ResponseEntity.ok(response);
+  }
+
+  // 2. 단일 챕터 학습 데이터(단어+퀴즈) 조회
+  @GetMapping("/{chapterId}")
+  public ResponseEntity<ChapterLearningResponse> getChapterLearningData(
+      @PathVariable Long chapterId,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    ChapterLearningResponse response = learningService.getChapterLearningData(principal.getUserId(), chapterId);
+    return ResponseEntity.ok(response);
+  }
+
+  // 3. 단어장 완료 처리
+  @PostMapping("/{chapterId}/vocab-complete")
+  public ResponseEntity<Void> completeVocabulary(
+      @PathVariable Long chapterId,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    learningService.completeVocabulary(principal.getUserId(), chapterId);
+    return ResponseEntity.ok().build();
+  }
+
+  // 4. 퀴즈 1문제 제출 및 채점
+  @PostMapping("/{chapterId}/quizzes/{quizId}")
+  public ResponseEntity<QuizSubmitResponse> submitQuiz(
+      @PathVariable Long chapterId,
+      @PathVariable Long quizId,
+      @RequestBody QuizSubmitRequest request,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    QuizSubmitResponse response = learningService.submitQuizAnswer(principal.getUserId(), chapterId, quizId, request);
+    return ResponseEntity.ok(response);
+  }
+
+  // 5. 챕터 최종 결과 조회
+  @GetMapping("/{chapterId}/result")
+  public ResponseEntity<ChapterResultResponse> getChapterResult(
+      @PathVariable Long chapterId,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    ChapterResultResponse response = learningService.getChapterResult(principal.getUserId(), chapterId);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/controller/LearningController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/controller/LearningController.java
@@ -1,6 +1,7 @@
 package com.ogi1t.bitelearn.domain.learning.controller;
 
 import com.ogi1t.bitelearn.domain.learning.dto.request.QuizSubmitRequest;
+import com.ogi1t.bitelearn.domain.learning.dto.response.CategoryTopicResponse;
 import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterLearningResponse;
 import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterListResponse;
 import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterResultResponse;
@@ -13,6 +14,7 @@ import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
 import com.ogi1t.bitelearn.global.security.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,14 +22,21 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Learning API", description = "학습 API")
 @RestController
-@RequestMapping("/learning/chapters")
+@RequestMapping("/learning")
 @RequiredArgsConstructor
 public class LearningController {
 
   private final LearningService learningService;
 
+  @Operation(summary = "전체 카테고리 및 주제 목록 조회", description = "메인 화면 구성을 위한 대분류(Category) 및 중분류(Topic) 전체 목록을 조회합니다. (비회원 접근 가능)")
+  @GetMapping("/categories")
+  public ResponseEntity<List<CategoryTopicResponse>> getAllCategoriesAndTopics() {
+    List<CategoryTopicResponse> response = learningService.getAllCategoriesAndTopics();
+    return ResponseEntity.ok(response);
+  }
+
   @Operation(summary = "챕터 목록 조회", description = "카테고리와 주제에 맞는 챕터 목록을 조회합니다. (비회원 접근 가능)")
-  @GetMapping
+  @GetMapping("/chapters")
   public ResponseEntity<ChapterListResponse> getChapters(
       @RequestParam Category category,
       @RequestParam Topic topic,
@@ -41,7 +50,7 @@ public class LearningController {
   }
 
   @Operation(summary = "단일 챕터 학습 데이터 조회", description = "챕터 진입 시 단어장과 퀴즈(정답 제외) 데이터를 조회합니다.")
-  @GetMapping("/{chapterId}")
+  @GetMapping("/chapters/{chapterId}")
   public ResponseEntity<ChapterLearningResponse> getChapterLearningData(
       @PathVariable Long chapterId,
       @AuthenticationPrincipal CustomPrincipal principal) {
@@ -56,7 +65,7 @@ public class LearningController {
   }
 
   @Operation(summary = "단어장 완료 처리", description = "단어장 학습을 마치고 퀴즈로 넘어갈 때 진행 상태를 업데이트합니다.")
-  @PostMapping("/{chapterId}/vocab-complete")
+  @PostMapping("/chapters/{chapterId}/vocab-complete")
   public ResponseEntity<Void> completeVocabulary(
       @PathVariable Long chapterId,
       @AuthenticationPrincipal CustomPrincipal principal) {
@@ -71,7 +80,7 @@ public class LearningController {
   }
 
   @Operation(summary = "퀴즈 정답 제출 및 채점", description = "한 문제의 정답을 제출하고 채점 결과를 받습니다.")
-  @PostMapping("/{chapterId}/quizzes/{quizId}")
+  @PostMapping("/chapters/{chapterId}/quizzes/{quizId}")
   public ResponseEntity<QuizSubmitResponse> submitQuiz(
       @PathVariable Long chapterId,
       @PathVariable Long quizId,
@@ -88,7 +97,7 @@ public class LearningController {
   }
 
   @Operation(summary = "챕터 최종 결과 조회", description = "챕터 학습을 마친 후 정답률과 보상 결과를 조회합니다.")
-  @GetMapping("/{chapterId}/result")
+  @GetMapping("/chapters/{chapterId}/result")
   public ResponseEntity<ChapterResultResponse> getChapterResult(
       @PathVariable Long chapterId,
       @AuthenticationPrincipal CustomPrincipal principal) {

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/info/QuizInfo.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/info/QuizInfo.java
@@ -1,0 +1,33 @@
+package com.ogi1t.bitelearn.domain.learning.dto.info;
+
+import com.ogi1t.bitelearn.domain.learning.entity.Quiz;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.QuizType;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class QuizInfo {
+  private Long quizId;
+  private Integer sequence;
+  private QuizType type;
+  private String passageTitle;
+  private String passageContent;
+  private String questionImageUrl;
+  private String questionTitle;
+  private Map<String, Object> specificData;
+
+  public static QuizInfo withoutAnswer(Quiz q) {
+    return new QuizInfo(
+        q.getId(),
+        q.getSequence(),
+        q.getQuizType(),
+        q.getPassageTitle(),
+        q.getPassageContent(),
+        q.getQuestionImageUrl(),
+        q.getQuestionTitle(),
+        q.getSpecificData()
+    );
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/info/QuizInfo.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/info/QuizInfo.java
@@ -2,12 +2,11 @@ package com.ogi1t.bitelearn.domain.learning.dto.info;
 
 import com.ogi1t.bitelearn.domain.learning.entity.Quiz;
 import com.ogi1t.bitelearn.domain.learning.entity.enums.QuizType;
-import java.util.Map;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
+@Builder
 public class QuizInfo {
   private Long quizId;
   private Integer sequence;
@@ -16,18 +15,24 @@ public class QuizInfo {
   private String passageContent;
   private String questionImageUrl;
   private String questionTitle;
-  private Map<String, Object> specificData;
+  private SpecificDataInfo specificData;
 
-  public static QuizInfo withoutAnswer(Quiz q) {
-    return new QuizInfo(
-        q.getId(),
-        q.getSequence(),
-        q.getQuizType(),
-        q.getPassageTitle(),
-        q.getPassageContent(),
-        q.getQuestionImageUrl(),
-        q.getQuestionTitle(),
-        q.getSpecificData()
-    );
+  public static QuizInfo withoutAnswer(Quiz quiz) {
+    // 안전장치: DB에 특정 퀴즈의 JSON 데이터가 아예 없더라도 뻗지 않고,
+    // 빈 배열 3개가 들어있는 껍데기를 만들어서 프론트로 넘겨줌
+    SpecificDataInfo safeSpecificData = (quiz.getSpecificData() != null)
+        ? quiz.getSpecificData()
+        : SpecificDataInfo.builder().build();
+
+    return QuizInfo.builder()
+        .quizId(quiz.getId())
+        .sequence(quiz.getSequence())
+        .type(quiz.getQuizType())
+        .passageTitle(quiz.getPassageTitle())
+        .passageContent(quiz.getPassageContent())
+        .questionImageUrl(quiz.getQuestionImageUrl())
+        .questionTitle(quiz.getQuestionTitle())
+        .specificData(safeSpecificData) // 안전장치가 적용된 객체 주입
+        .build();
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/info/SpecificDataInfo.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/info/SpecificDataInfo.java
@@ -1,0 +1,43 @@
+package com.ogi1t.bitelearn.domain.learning.dto.info;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SpecificDataInfo {
+
+  // 데이터가 없어도 null 대신 빈 배열([])이 들어가도록 초기화
+  @Builder.Default
+  private List<String> options = new ArrayList<>();
+
+  @Builder.Default
+  private List<DialogueInfo> dialogues = new ArrayList<>();
+
+  @Builder.Default
+  private List<DocumentElementInfo> documentElements = new ArrayList<>();
+
+  // --- 내부 클래스 ---
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class DocumentElementInfo {
+    private String key;
+    private String value;
+  }
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class DialogueInfo {
+    private String speaker;
+    private String message;
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/info/SpecificDataInfo.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/info/SpecificDataInfo.java
@@ -23,6 +23,9 @@ public class SpecificDataInfo {
   @Builder.Default
   private List<DocumentElementInfo> documentElements = new ArrayList<>();
 
+  private String documentTitle;    // 문서 제목 (예: "[표제부]")
+  private String documentSubtitle; // 문서 부제목 (예: "(건물의 표시)")
+
   // --- 내부 클래스 ---
 
   @Getter

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/info/VocabInfo.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/info/VocabInfo.java
@@ -1,0 +1,27 @@
+package com.ogi1t.bitelearn.domain.learning.dto.info;
+
+import com.ogi1t.bitelearn.domain.learning.entity.Vocabulary;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class VocabInfo {
+  private Long id;
+  private String frontMain;
+  private String frontSub;
+  private String frontImageUrl;
+  private String backMain;
+  private String backSub;
+
+  public static VocabInfo from(Vocabulary v) {
+    return new VocabInfo(
+        v.getId(),
+        v.getFrontMain(),
+        v.getFrontSub(),
+        v.getFrontImageUrl(),
+        v.getBackMain(),
+        v.getBackSub()
+    );
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/request/QuizSubmitRequest.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/request/QuizSubmitRequest.java
@@ -1,0 +1,12 @@
+package com.ogi1t.bitelearn.domain.learning.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizSubmitRequest {
+  private String selectedAnswer;
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/CategoryTopicResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/CategoryTopicResponse.java
@@ -1,0 +1,22 @@
+package com.ogi1t.bitelearn.domain.learning.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CategoryTopicResponse {
+  private String categoryCode; // 예: "REAL_ESTATE_HOUSING"
+  private String categoryName; // 예: "부동산"
+  private List<TopicDto> topics;
+
+  @Getter
+  @AllArgsConstructor
+  public static class TopicDto {
+    private String topicCode; // 예: "MONTHLY_RENT"
+    private String topicName; // 예: "월세"
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterLearningResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterLearningResponse.java
@@ -10,8 +10,10 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ChapterLearningResponse {
-  private String chapterTitle;
+  private String category;
+  private String topic;
 
+  private String chapterTitle;
   private String prologueSubtitle;
   private String prologueContent;
   private String currentGoal;

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterLearningResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterLearningResponse.java
@@ -23,4 +23,6 @@ public class ChapterLearningResponse {
   private Integer resumeQuizSequence;
   private List<VocabInfo> vocabs;
   private List<QuizInfo> quizzes;
+
+  private String closingMessage;
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterLearningResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterLearningResponse.java
@@ -10,6 +10,13 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ChapterLearningResponse {
+  private String chapterTitle;
+
+  private String prologueSubtitle;
+  private String prologueContent;
+  private String currentGoal;
+  private List<String> coreKeywords;
+
   private ProgressStatus currentStatus;
   private Integer resumeQuizSequence;
   private List<VocabInfo> vocabs;

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterLearningResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterLearningResponse.java
@@ -1,0 +1,17 @@
+package com.ogi1t.bitelearn.domain.learning.dto.response;
+
+import com.ogi1t.bitelearn.domain.learning.dto.info.QuizInfo;
+import com.ogi1t.bitelearn.domain.learning.dto.info.VocabInfo;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.ProgressStatus;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChapterLearningResponse {
+  private ProgressStatus currentStatus;
+  private Integer resumeQuizSequence;
+  private List<VocabInfo> vocabs;
+  private List<QuizInfo> quizzes;
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterLearningResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterLearningResponse.java
@@ -10,6 +10,10 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ChapterLearningResponse {
+
+  private Long chapterId;
+  private Integer chapterSequence;
+
   private String category;
   private String topic;
 

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterListResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterListResponse.java
@@ -1,0 +1,21 @@
+package com.ogi1t.bitelearn.domain.learning.dto.response;
+
+import com.ogi1t.bitelearn.domain.learning.entity.enums.ProgressStatus;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChapterListResponse {
+  private List<ChapterSummaryDto> chapters;
+
+  @Getter
+  @AllArgsConstructor
+  public static class ChapterSummaryDto {
+    private Long chapterId;
+    private String title;
+    private Integer sequence;
+    private ProgressStatus status;
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterResultResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterResultResponse.java
@@ -9,5 +9,10 @@ public class ChapterResultResponse {
   private int correctCount;
   private int totalCount;
   private int accuracyRate;
+
   private int earnedBytes;
+  private int lostBytes;
+
+  private int currentLevel;
+  private int currentTotalBytes;
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterResultResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/ChapterResultResponse.java
@@ -1,0 +1,13 @@
+package com.ogi1t.bitelearn.domain.learning.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChapterResultResponse {
+  private int correctCount;
+  private int totalCount;
+  private int accuracyRate;
+  private int earnedBytes;
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/QuizSubmitResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/dto/response/QuizSubmitResponse.java
@@ -1,0 +1,14 @@
+package com.ogi1t.bitelearn.domain.learning.dto.response;
+
+import com.ogi1t.bitelearn.domain.learning.entity.enums.ProgressStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class QuizSubmitResponse {
+  private boolean isCorrect;
+  private String correctAnswer;
+  private String explanation;
+  private ProgressStatus newStatus;
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Chapter.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Chapter.java
@@ -33,4 +33,7 @@ public class Chapter {
   private String coreKeywords; // 핵심 내용 키워드
 
   private Integer sequence; // 챕터 순서 (1, 2, 3...)
+
+  @Column(columnDefinition = "TEXT")
+  private String closingMessage; // 마무리 멘트
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Chapter.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Chapter.java
@@ -3,6 +3,7 @@ package com.ogi1t.bitelearn.domain.learning.entity;
 import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
 import com.ogi1t.bitelearn.domain.learning.entity.enums.Topic;
 import jakarta.persistence.*;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +22,15 @@ public class Chapter {
   private Topic topic;
 
   private String title;
+
+  private String prologueSubtitle; // 프롤로그 소제목
+
+  @Column(columnDefinition = "TEXT")
+  private String prologueContent; // 프롤로그 내용
+
+  private String currentGoal; // 이번 목표
+
+  private String coreKeywords; // 핵심 내용 키워드
 
   private Integer sequence; // 챕터 순서 (1, 2, 3...)
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Chapter.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Chapter.java
@@ -1,0 +1,26 @@
+package com.ogi1t.bitelearn.domain.learning.entity;
+
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Topic;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Chapter {
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  private Category category;
+
+  @Enumerated(EnumType.STRING)
+  private Topic topic;
+
+  private String title;
+
+  private Integer sequence; // 챕터 순서 (1, 2, 3...)
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/LearningProgress.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/LearningProgress.java
@@ -25,6 +25,10 @@ public class LearningProgress {
 
   private Integer lastSolvedQuizSequence;
 
+  // 보상 수령 여부 (기본값 false)
+  @Column(nullable = false)
+  private boolean isRewarded = false;
+
   @CreationTimestamp
   private LocalDateTime createdAt;
 
@@ -48,5 +52,9 @@ public class LearningProgress {
     if (this.status == ProgressStatus.READY) {
       this.status = ProgressStatus.QUIZ_IN_PROGRESS;
     }
+  }
+
+  public void markAsRewarded() {
+    this.isRewarded = true;
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/LearningProgress.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/LearningProgress.java
@@ -1,0 +1,52 @@
+package com.ogi1t.bitelearn.domain.learning.entity;
+
+import com.ogi1t.bitelearn.domain.learning.entity.enums.ProgressStatus;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LearningProgress {
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Long userId;
+  private Long chapterId;
+
+  @Enumerated(EnumType.STRING)
+  private ProgressStatus status;
+
+  private Integer lastSolvedQuizSequence;
+
+  @CreationTimestamp
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  private LocalDateTime updatedAt;
+
+  @Builder
+  public LearningProgress(Long userId, Long chapterId) {
+    this.userId = userId;
+    this.chapterId = chapterId;
+    this.status = ProgressStatus.READY;
+    this.lastSolvedQuizSequence = 0;
+  }
+
+  public void updateProgress(Integer currentQuizSequence, ProgressStatus newStatus) {
+    this.lastSolvedQuizSequence = currentQuizSequence;
+    this.status = newStatus;
+  }
+
+  public void startQuiz() {
+    if (this.status == ProgressStatus.READY) {
+      this.status = ProgressStatus.QUIZ_IN_PROGRESS;
+    }
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Quiz.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Quiz.java
@@ -1,8 +1,8 @@
 package com.ogi1t.bitelearn.domain.learning.entity;
 
+import com.ogi1t.bitelearn.domain.learning.dto.info.SpecificDataInfo;
 import com.ogi1t.bitelearn.domain.learning.entity.enums.QuizType;
 import jakarta.persistence.*;
-import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,9 +31,10 @@ public class Quiz {
   private String questionImageUrl;
   private String questionTitle;
 
+  // DB의 JSON 데이터를 자바 객체로 변환
   @JdbcTypeCode(SqlTypes.JSON)
   @Column(columnDefinition = "json")
-  private Map<String, Object> specificData;
+  private SpecificDataInfo specificData;
 
   private String correctAnswer;
 

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Quiz.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Quiz.java
@@ -1,0 +1,42 @@
+package com.ogi1t.bitelearn.domain.learning.entity;
+
+import com.ogi1t.bitelearn.domain.learning.entity.enums.QuizType;
+import jakarta.persistence.*;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Quiz {
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Long chapterId;
+
+  private Integer sequence; // 1 ~ 12
+
+  @Enumerated(EnumType.STRING)
+  private QuizType quizType;
+
+  private String passageTitle;
+
+  @Column(columnDefinition = "TEXT")
+  private String passageContent;
+
+  private String questionImageUrl;
+  private String questionTitle;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "json")
+  private Map<String, Object> specificData;
+
+  private String correctAnswer;
+
+  @Column(columnDefinition = "TEXT")
+  private String explanation;
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/UserQuizAnswer.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/UserQuizAnswer.java
@@ -15,14 +15,23 @@ public class UserQuizAnswer {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Column(nullable = false)
   private Long userId;
+
+  @Column(nullable = false)
   private Long chapterId;
+
+  @Column(nullable = false)
   private Long quizId;
 
+  @Column(nullable = false, length = 500)
   private String selectedAnswer;
+
+  @Column(nullable = false)
   private boolean isCorrect;
 
   @CreationTimestamp
+  @Column(nullable = false, updatable = false)
   private LocalDateTime createdAt;
 
   @Builder

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/UserQuizAnswer.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/UserQuizAnswer.java
@@ -9,6 +9,10 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
+@Table(name = "user_quiz_answer", indexes = {
+    // 유저의 오답 노트를 빠르게 조회하고 최신순으로 정렬하기 위한 복합 인덱스
+    @Index(name = "idx_user_correct_id", columnList = "user_id, is_correct, id DESC")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserQuizAnswer {

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/UserQuizAnswer.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/UserQuizAnswer.java
@@ -1,0 +1,36 @@
+package com.ogi1t.bitelearn.domain.learning.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserQuizAnswer {
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Long userId;
+  private Long chapterId;
+  private Long quizId;
+
+  private String selectedAnswer;
+  private boolean isCorrect;
+
+  @CreationTimestamp
+  private LocalDateTime createdAt;
+
+  @Builder
+  public UserQuizAnswer(Long userId, Long chapterId, Long quizId, String selectedAnswer, boolean isCorrect) {
+    this.userId = userId;
+    this.chapterId = chapterId;
+    this.quizId = quizId;
+    this.selectedAnswer = selectedAnswer;
+    this.isCorrect = isCorrect;
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Vocabulary.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/Vocabulary.java
@@ -1,0 +1,23 @@
+package com.ogi1t.bitelearn.domain.learning.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Vocabulary {
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Long chapterId;
+
+  private String frontMain;
+  private String frontSub;
+  private String frontImageUrl;
+
+  private String backMain;
+  private String backSub;
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/Category.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/Category.java
@@ -1,7 +1,38 @@
 package com.ogi1t.bitelearn.domain.learning.entity.enums;
 
+import java.util.Arrays;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Category {
-  REAL_ESTATE, // 부동산
-  FINANCE,     // 금융
-  LAW          // 법률 등 (확장 가능)
+
+  REAL_ESTATE_HOUSING("부동산 · 주거", Arrays.asList(
+      Topic.JEONSE,
+      Topic.MONTHLY_RENT,
+      Topic.BUYING
+  )),
+
+  LIVING_FINANCE_EMPLOYMENT("생활금융 · 고용", Arrays.asList(
+      Topic.INCOME_EXPENDITURE,
+      Topic.CREDIT_LIABILITIES,
+      Topic.WORK_WELFARE
+  )),
+
+  CAREER_TAX("커리어 · 세무", Arrays.asList(
+      Topic.SALARY_REAL_INCOME,
+      Topic.INCOME_TAX_DEDUCTION,
+      Topic.COMPREHENSIVE_INCOME_TAX
+  )),
+
+  ASSET_MANAGEMENT_INVESTMENT("자산운용 · 투자", Arrays.asList(
+      Topic.STOCK,
+      Topic.BOND_DEPOSIT,
+      Topic.ANNUITY
+  ));
+
+  private final String description;
+  private final List<Topic> topics;
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/Category.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/Category.java
@@ -1,0 +1,7 @@
+package com.ogi1t.bitelearn.domain.learning.entity.enums;
+
+public enum Category {
+  REAL_ESTATE, // 부동산
+  FINANCE,     // 금융
+  LAW          // 법률 등 (확장 가능)
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/ProgressStatus.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/ProgressStatus.java
@@ -1,0 +1,7 @@
+package com.ogi1t.bitelearn.domain.learning.entity.enums;
+
+public enum ProgressStatus {
+  READY,              // 시작 전 (단어장 단계)
+  QUIZ_IN_PROGRESS,   // 퀴즈 푸는 중
+  COMPLETED           // 챕터 완료
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/QuizType.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/QuizType.java
@@ -2,8 +2,8 @@ package com.ogi1t.bitelearn.domain.learning.entity.enums;
 
 public enum QuizType {
   TEXT_MCQ,       // 일반 객관식
-  DOC_SELECT,     // 문서 선택형 객관식
-  DOC_MULTI,      // 문서 다지선다형
+  DOC_CLICK,      // 문서 클릭형 객관식
+  DOC_MCQ,        // 문서 객관식
   DIALOGUE_MCQ,   // 대화형 객관식
   DIALOGUE_OX     // 대화형 OX
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/QuizType.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/QuizType.java
@@ -1,0 +1,9 @@
+package com.ogi1t.bitelearn.domain.learning.entity.enums;
+
+public enum QuizType {
+  TEXT_MCQ,       // 일반 객관식
+  DOC_SELECT,     // 문서 선택형 객관식
+  DOC_MULTI,      // 문서 다지선다형
+  DIALOGUE_MCQ,   // 대화형 객관식
+  DIALOGUE_OX     // 대화형 OX
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/Topic.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/Topic.java
@@ -1,7 +1,31 @@
 package com.ogi1t.bitelearn.domain.learning.entity.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Topic {
-  JEONSE,         // 전세
-  MONTHLY_RENT,   // 월세
-  BUYING          // 매매 등
+
+  // 부동산 · 주거
+  JEONSE("전세"),
+  MONTHLY_RENT("월세"),
+  BUYING("매매"),
+
+  // 생활금융 · 고용
+  INCOME_EXPENDITURE("소득 및 지출"),
+  CREDIT_LIABILITIES("신용 및 부채"),
+  WORK_WELFARE("근로 및 복지"),
+
+  // 커리어 · 세무
+  SALARY_REAL_INCOME("월급과 실수령액"),
+  INCOME_TAX_DEDUCTION("소득공제와 세액공제"),
+  COMPREHENSIVE_INCOME_TAX("종합소득세"),
+
+  // 자산운용 · 투자
+  STOCK("주식"),
+  BOND_DEPOSIT("채권 · 예금"),
+  ANNUITY("연금");
+
+  private final String description; // 프론트엔드에 보여줄 한글 이름
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/Topic.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/entity/enums/Topic.java
@@ -1,0 +1,7 @@
+package com.ogi1t.bitelearn.domain.learning.entity.enums;
+
+public enum Topic {
+  JEONSE,         // 전세
+  MONTHLY_RENT,   // 월세
+  BUYING          // 매매 등
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/ChapterRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/ChapterRepository.java
@@ -1,0 +1,11 @@
+package com.ogi1t.bitelearn.domain.learning.repository;
+
+import com.ogi1t.bitelearn.domain.learning.entity.Chapter;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Topic;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChapterRepository extends JpaRepository<Chapter, Long> {
+  List<Chapter> findByCategoryAndTopicOrderBySequenceAsc(Category category, Topic topic);
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/LearningProgressRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/LearningProgressRepository.java
@@ -8,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface LearningProgressRepository extends JpaRepository<LearningProgress, Long> {
   Optional<LearningProgress> findByUserIdAndChapterId(Long userId, Long chapterId);
   List<LearningProgress> findByUserIdAndChapterIdIn(Long userId, List<Long> chapterIds);
+  Optional<LearningProgress> findFirstByUserIdOrderByUpdatedAtDesc(Long userId);
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/LearningProgressRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/LearningProgressRepository.java
@@ -1,0 +1,11 @@
+package com.ogi1t.bitelearn.domain.learning.repository;
+
+import com.ogi1t.bitelearn.domain.learning.entity.LearningProgress;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LearningProgressRepository extends JpaRepository<LearningProgress, Long> {
+  Optional<LearningProgress> findByUserIdAndChapterId(Long userId, Long chapterId);
+  List<LearningProgress> findByUserIdAndChapterIdIn(Long userId, List<Long> chapterIds);
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/QuizRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/QuizRepository.java
@@ -1,0 +1,10 @@
+package com.ogi1t.bitelearn.domain.learning.repository;
+
+import com.ogi1t.bitelearn.domain.learning.entity.Quiz;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+  List<Quiz> findByChapterIdOrderBySequenceAsc(Long chapterId);
+  int countByChapterId(Long chapterId);
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
@@ -1,8 +1,38 @@
 package com.ogi1t.bitelearn.domain.learning.repository;
 
 import com.ogi1t.bitelearn.domain.learning.entity.UserQuizAnswer;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
+import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse.IncorrectNoteDto;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, Long> {
+
+  // 챕터 결과 채점용 메서드
   int countByUserIdAndChapterIdAndIsCorrectTrue(Long userId, Long chapterId);
+
+  // 전체 오답 노트 조회 (카테고리 조건 없을 때)
+  @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +
+      "uqa.id, c.id, q.id, c.category, c.topic, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " +
+      "FROM UserQuizAnswer uqa " +
+      "JOIN Quiz q ON uqa.quizId = q.id " +
+      "JOIN Chapter c ON uqa.chapterId = c.id " +
+      "WHERE uqa.userId = :userId AND uqa.isCorrect = false " +
+      "ORDER BY uqa.createdAt DESC")
+  List<IncorrectNoteDto> findAllIncorrectNotesByUserId(@Param("userId") Long userId);
+
+  // 특정 카테고리의 오답 노트 조회 (예: 부동산만 볼 때)
+  @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +
+      "uqa.id, c.id, q.id, c.category, c.topic, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " +
+      "FROM UserQuizAnswer uqa " +
+      "JOIN Quiz q ON uqa.quizId = q.id " +
+      "JOIN Chapter c ON uqa.chapterId = c.id " +
+      "WHERE uqa.userId = :userId AND uqa.isCorrect = false AND c.category = :category " +
+      "ORDER BY uqa.createdAt DESC")
+  List<IncorrectNoteDto> findIncorrectNotesByUserIdAndCategory(@Param("userId") Long userId, @Param("category") Category category);
+
+  // 총 오답 개수 카운트
+  int countByUserIdAndIsCorrectFalse(Long userId);
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
@@ -10,8 +10,14 @@ import org.springframework.data.repository.query.Param;
 
 public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, Long> {
 
-  // 챕터 결과 채점용 메서드
-  int countByUserIdAndChapterIdAndIsCorrectTrue(Long userId, Long chapterId);
+  // 챕터 결과 조회용 (재시험 누적 방지): 문제별 최신 풀이 기록 중 정답(isCorrect=true) 개수 조회
+  @Query("SELECT COUNT(u) FROM UserQuizAnswer u " +
+      "WHERE u.id IN (" +
+      "  SELECT MAX(u2.id) FROM UserQuizAnswer u2 " +
+      "  WHERE u2.userId = :userId AND u2.chapterId = :chapterId " +
+      "  GROUP BY u2.quizId" +
+      ") AND u.isCorrect = true")
+  int countLatestCorrectAnswers(@Param("userId") Long userId, @Param("chapterId") Long chapterId);
 
   // 전체 오답 노트 조회 (카테고리 조건 없을 때)
   @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
@@ -22,7 +22,7 @@ public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, 
 
   // 전체 오답 노트 무한 스크롤 조회 (카테고리 조건 없을 때) (uqa.id < :cursor 조건 추가, Pageable 추가)
   @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +
-      "uqa.id, c.id, q.id, c.category, c.topic, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " +
+      "uqa.id, c.id, q.id, c.category, c.topic, c.sequence, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " + // ✨ c.sequence 위치 변경!
       "FROM UserQuizAnswer uqa " +
       "JOIN Quiz q ON uqa.quizId = q.id " +
       "JOIN Chapter c ON uqa.chapterId = c.id " +
@@ -32,7 +32,7 @@ public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, 
 
   // 특정 카테고리의 오답 노트 무한 스크롤 조회 (예: 부동산만 볼 때)
   @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +
-      "uqa.id, c.id, q.id, c.category, c.topic, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " +
+      "uqa.id, c.id, q.id, c.category, c.topic, c.sequence, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " + // ✨ c.sequence 위치 변경!
       "FROM UserQuizAnswer uqa " +
       "JOIN Quiz q ON uqa.quizId = q.id " +
       "JOIN Chapter c ON uqa.chapterId = c.id " +

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
@@ -1,0 +1,8 @@
+package com.ogi1t.bitelearn.domain.learning.repository;
+
+import com.ogi1t.bitelearn.domain.learning.entity.UserQuizAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, Long> {
+  int countByUserIdAndChapterIdAndIsCorrectTrue(Long userId, Long chapterId);
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
@@ -20,9 +20,9 @@ public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, 
       ") AND u.isCorrect = true")
   int countLatestCorrectAnswers(@Param("userId") Long userId, @Param("chapterId") Long chapterId);
 
-  // 전체 오답 노트 무한 스크롤 조회 (카테고리 조건 없을 때) (uqa.id < :cursor 조건 추가, Pageable 추가)
+  // 전체 오답 노트 무한 스크롤 조회 (카테고리 조건 없을 때)
   @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +
-      "uqa.id, c.id, q.id, c.category, c.topic, c.sequence, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " + // ✨ c.sequence 위치 변경!
+      "uqa.id, c.id, q.id, c.category, c.topic, c.title, c.sequence, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " +
       "FROM UserQuizAnswer uqa " +
       "JOIN Quiz q ON uqa.quizId = q.id " +
       "JOIN Chapter c ON uqa.chapterId = c.id " +
@@ -30,16 +30,15 @@ public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, 
       "ORDER BY uqa.id DESC")
   List<IncorrectNoteDto> findAllIncorrectNotesByCursor(@Param("userId") Long userId, @Param("cursor") Long cursor, Pageable pageable);
 
-  // 특정 카테고리의 오답 노트 무한 스크롤 조회 (예: 부동산만 볼 때)
+  // 특정 카테고리의 오답 노트 무한 스크롤 조회
   @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +
-      "uqa.id, c.id, q.id, c.category, c.topic, c.sequence, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " + // ✨ c.sequence 위치 변경!
+      "uqa.id, c.id, q.id, c.category, c.topic, c.title, c.sequence, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " +
       "FROM UserQuizAnswer uqa " +
       "JOIN Quiz q ON uqa.quizId = q.id " +
       "JOIN Chapter c ON uqa.chapterId = c.id " +
       "WHERE uqa.userId = :userId AND uqa.isCorrect = false AND c.category = :category AND uqa.id < :cursor " +
       "ORDER BY uqa.id DESC")
   List<IncorrectNoteDto> findIncorrectNotesByCategoryAndCursor(@Param("userId") Long userId, @Param("category") Category category, @Param("cursor") Long cursor, Pageable pageable);
-
   // 총 오답 개수 카운트
   int countByUserIdAndIsCorrectFalse(Long userId);
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
@@ -4,6 +4,7 @@ import com.ogi1t.bitelearn.domain.learning.entity.UserQuizAnswer;
 import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
 import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse.IncorrectNoteDto;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,25 +20,25 @@ public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, 
       ") AND u.isCorrect = true")
   int countLatestCorrectAnswers(@Param("userId") Long userId, @Param("chapterId") Long chapterId);
 
-  // 전체 오답 노트 조회 (카테고리 조건 없을 때)
+  // 전체 오답 노트 무한 스크롤 조회 (카테고리 조건 없을 때) (uqa.id < :cursor 조건 추가, Pageable 추가)
   @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +
       "uqa.id, c.id, q.id, c.category, c.topic, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " +
       "FROM UserQuizAnswer uqa " +
       "JOIN Quiz q ON uqa.quizId = q.id " +
       "JOIN Chapter c ON uqa.chapterId = c.id " +
-      "WHERE uqa.userId = :userId AND uqa.isCorrect = false " +
-      "ORDER BY uqa.createdAt DESC")
-  List<IncorrectNoteDto> findAllIncorrectNotesByUserId(@Param("userId") Long userId);
+      "WHERE uqa.userId = :userId AND uqa.isCorrect = false AND uqa.id < :cursor " +
+      "ORDER BY uqa.id DESC")
+  List<IncorrectNoteDto> findAllIncorrectNotesByCursor(@Param("userId") Long userId, @Param("cursor") Long cursor, Pageable pageable);
 
-  // 특정 카테고리의 오답 노트 조회 (예: 부동산만 볼 때)
+  // 특정 카테고리의 오답 노트 무한 스크롤 조회 (예: 부동산만 볼 때)
   @Query("SELECT new com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse$IncorrectNoteDto(" +
       "uqa.id, c.id, q.id, c.category, c.topic, q.questionTitle, uqa.selectedAnswer, q.correctAnswer, uqa.createdAt) " +
       "FROM UserQuizAnswer uqa " +
       "JOIN Quiz q ON uqa.quizId = q.id " +
       "JOIN Chapter c ON uqa.chapterId = c.id " +
-      "WHERE uqa.userId = :userId AND uqa.isCorrect = false AND c.category = :category " +
-      "ORDER BY uqa.createdAt DESC")
-  List<IncorrectNoteDto> findIncorrectNotesByUserIdAndCategory(@Param("userId") Long userId, @Param("category") Category category);
+      "WHERE uqa.userId = :userId AND uqa.isCorrect = false AND c.category = :category AND uqa.id < :cursor " +
+      "ORDER BY uqa.id DESC")
+  List<IncorrectNoteDto> findIncorrectNotesByCategoryAndCursor(@Param("userId") Long userId, @Param("category") Category category, @Param("cursor") Long cursor, Pageable pageable);
 
   // 총 오답 개수 카운트
   int countByUserIdAndIsCorrectFalse(Long userId);

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/UserQuizAnswerRepository.java
@@ -41,4 +41,7 @@ public interface UserQuizAnswerRepository extends JpaRepository<UserQuizAnswer, 
   List<IncorrectNoteDto> findIncorrectNotesByCategoryAndCursor(@Param("userId") Long userId, @Param("category") Category category, @Param("cursor") Long cursor, Pageable pageable);
   // 총 오답 개수 카운트
   int countByUserIdAndIsCorrectFalse(Long userId);
+
+  @Query("SELECT DISTINCT u.chapterId FROM UserQuizAnswer u WHERE u.userId = :userId")
+  List<Long> findAttemptedChapterIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/VocabularyRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/repository/VocabularyRepository.java
@@ -1,0 +1,9 @@
+package com.ogi1t.bitelearn.domain.learning.repository;
+
+import com.ogi1t.bitelearn.domain.learning.entity.Vocabulary;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VocabularyRepository extends JpaRepository<Vocabulary, Long> {
+  List<Vocabulary> findByChapterId(Long chapterId);
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
@@ -129,6 +129,8 @@ public class LearningService {
         .collect(Collectors.toList());
 
     return ChapterLearningResponse.builder()
+        .chapterId(chapter.getId())
+        .chapterSequence(chapter.getSequence())
         .category(chapter.getCategory().name())
         .topic(chapter.getTopic().name())
         .chapterTitle(chapter.getTitle())

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
@@ -1,0 +1,146 @@
+package com.ogi1t.bitelearn.domain.learning.service;
+
+import com.ogi1t.bitelearn.domain.learning.dto.request.QuizSubmitRequest;
+import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterLearningResponse;
+import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterListResponse;
+import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterResultResponse;
+import com.ogi1t.bitelearn.domain.learning.dto.response.QuizSubmitResponse;
+import com.ogi1t.bitelearn.domain.learning.dto.info.QuizInfo;
+import com.ogi1t.bitelearn.domain.learning.dto.info.VocabInfo;
+import com.ogi1t.bitelearn.domain.learning.entity.Chapter;
+import com.ogi1t.bitelearn.domain.learning.entity.LearningProgress;
+import com.ogi1t.bitelearn.domain.learning.entity.Quiz;
+import com.ogi1t.bitelearn.domain.learning.entity.UserQuizAnswer;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.ProgressStatus;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Topic;
+import com.ogi1t.bitelearn.domain.learning.repository.ChapterRepository;
+import com.ogi1t.bitelearn.domain.learning.repository.LearningProgressRepository;
+import com.ogi1t.bitelearn.domain.learning.repository.QuizRepository;
+import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
+import com.ogi1t.bitelearn.domain.learning.repository.VocabularyRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LearningService {
+
+  private final ChapterRepository chapterRepository;
+  private final VocabularyRepository vocabularyRepository;
+  private final QuizRepository quizRepository;
+  private final LearningProgressRepository progressRepository;
+  private final UserQuizAnswerRepository answerRepository;
+
+  // 1. 챕터 목록 조회
+  public ChapterListResponse getChaptersByCategoryAndTopic(Long userId, Category category, Topic topic) {
+    // 해당 카테고리/토픽의 챕터 목록 가져오기
+    List<Chapter> chapters = chapterRepository.findByCategoryAndTopicOrderBySequenceAsc(category, topic);
+
+    // 유저의 진행도 맵으로 만들기 (매핑 속도 최적화)
+    List<Long> chapterIds = chapters.stream().map(Chapter::getId).collect(Collectors.toList());
+    Map<Long, ProgressStatus> progressMap = progressRepository.findByUserIdAndChapterIdIn(userId, chapterIds)
+        .stream()
+        .collect(Collectors.toMap(LearningProgress::getChapterId, LearningProgress::getStatus));
+
+    // DTO로 변환 (진행도 정보가 없으면 기본값 READY 부여)
+    List<ChapterListResponse.ChapterSummaryDto> chapterDtos = chapters.stream()
+        .map(chapter -> new ChapterListResponse.ChapterSummaryDto(
+            chapter.getId(),
+            chapter.getTitle(),
+            chapter.getSequence(),
+            progressMap.getOrDefault(chapter.getId(), ProgressStatus.READY)
+        ))
+        .collect(Collectors.toList());
+
+    return new ChapterListResponse(chapterDtos);
+  }
+
+  // 2. 단일 챕터 학습 데이터 조회 (진행도 자동 생성 포함)
+  @Transactional
+  public ChapterLearningResponse getChapterLearningData(Long userId, Long chapterId) {
+    // 진행도가 없으면 새로 생성 (최초 진입)
+    LearningProgress progress = progressRepository.findByUserIdAndChapterId(userId, chapterId)
+        .orElseGet(() -> progressRepository.save(new LearningProgress(userId, chapterId)));
+
+    // 단어장 및 퀴즈(정답 제외) 조회
+    List<VocabInfo> vocabs = vocabularyRepository.findByChapterId(chapterId).stream()
+        .map(VocabInfo::from)
+        .collect(Collectors.toList());
+
+    List<QuizInfo> quizzes = quizRepository.findByChapterIdOrderBySequenceAsc(chapterId).stream()
+        .map(QuizInfo::withoutAnswer)
+        .collect(Collectors.toList());
+
+    return ChapterLearningResponse.builder()
+        .currentStatus(progress.getStatus())
+        .resumeQuizSequence(progress.getLastSolvedQuizSequence())
+        .vocabs(vocabs)
+        .quizzes(quizzes)
+        .build();
+  }
+
+  // 3. 단어장 완료 처리 (상태 변경)
+  @Transactional
+  public void completeVocabulary(Long userId, Long chapterId) {
+    LearningProgress progress = progressRepository.findByUserIdAndChapterId(userId, chapterId)
+        .orElseThrow(() -> new IllegalArgumentException("진행도 정보가 없습니다."));
+
+    // 단어장을 다 봤으므로 퀴즈 진행 상태로 변경
+    progress.startQuiz();
+  }
+
+  // 4. 퀴즈 제출 및 채점 (자동 저장)
+  @Transactional
+  public QuizSubmitResponse submitQuizAnswer(Long userId, Long chapterId, Long quizId, QuizSubmitRequest request) {
+    Quiz quiz = quizRepository.findById(quizId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 퀴즈입니다."));
+
+    // 정답 비교
+    boolean isCorrect = quiz.getCorrectAnswer().equals(request.getSelectedAnswer());
+
+    // 유저 답안 로깅
+    UserQuizAnswer answer = new UserQuizAnswer(userId, chapterId, quiz.getId(), request.getSelectedAnswer(), isCorrect);
+    answerRepository.save(answer);
+
+    // 진행도 업데이트 (이탈 시 여기부터 재개)
+    LearningProgress progress = progressRepository.findByUserIdAndChapterId(userId, chapterId)
+        .orElseThrow(() -> new IllegalArgumentException("진행도 정보가 없습니다."));
+
+    int totalQuizzes = quizRepository.countByChapterId(chapterId);
+
+    // 마지막 문제인지 확인 후 상태 업데이트
+    if (quiz.getSequence() >= totalQuizzes) {
+      progress.updateProgress(quiz.getSequence(), ProgressStatus.COMPLETED);
+      // TODO: (선택) 보상(바이트) 지급 로직을 여기에 추가할 수 있습니다.
+    } else {
+      progress.updateProgress(quiz.getSequence(), ProgressStatus.QUIZ_IN_PROGRESS);
+    }
+
+    return new QuizSubmitResponse(isCorrect, quiz.getCorrectAnswer(), quiz.getExplanation(), progress.getStatus());
+  }
+
+  // 5. 최종 결과 조회
+  public ChapterResultResponse getChapterResult(Long userId, Long chapterId) {
+    int totalQuizzes = quizRepository.countByChapterId(chapterId);
+    int correctQuizzes = answerRepository.countByUserIdAndChapterIdAndIsCorrectTrue(userId, chapterId);
+
+    // 0으로 나누기 방지
+    int accuracyRate = totalQuizzes > 0 ? (int) Math.round(((double) correctQuizzes / totalQuizzes) * 100) : 0;
+
+    // 임시 보상 로직 (기획에 따라 변경 가능)
+    int earnedBytes = accuracyRate >= 80 ? 500 : 100;
+
+    return ChapterResultResponse.builder()
+        .correctCount(correctQuizzes)
+        .totalCount(totalQuizzes)
+        .accuracyRate(accuracyRate)
+        .earnedBytes(earnedBytes)
+        .build();
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
@@ -19,6 +19,8 @@ import com.ogi1t.bitelearn.domain.learning.repository.LearningProgressRepository
 import com.ogi1t.bitelearn.domain.learning.repository.QuizRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.VocabularyRepository;
+import com.ogi1t.bitelearn.global.exception.BusinessException;
+import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -41,16 +43,18 @@ public class LearningService {
 
   // 1. 챕터 목록 조회
   public ChapterListResponse getChaptersByCategoryAndTopic(Long userId, Category category, Topic topic) {
-    // 해당 카테고리/토픽의 챕터 목록 가져오기
     List<Chapter> chapters = chapterRepository.findByCategoryAndTopicOrderBySequenceAsc(category, topic);
-
-    // 유저의 진행도 맵으로 만들기 (매핑 속도 최적화)
     List<Long> chapterIds = chapters.stream().map(Chapter::getId).collect(Collectors.toList());
-    Map<Long, ProgressStatus> progressMap = progressRepository.findByUserIdAndChapterIdIn(userId, chapterIds)
-        .stream()
-        .collect(Collectors.toMap(LearningProgress::getChapterId, LearningProgress::getStatus));
 
-    // DTO로 변환 (진행도 정보가 없으면 기본값 READY 부여)
+    Map<Long, ProgressStatus> progressMap;
+    if (userId != null) {
+      progressMap = progressRepository.findByUserIdAndChapterIdIn(userId, chapterIds)
+          .stream()
+          .collect(Collectors.toMap(LearningProgress::getChapterId, LearningProgress::getStatus));
+    } else {
+      progressMap = Collections.emptyMap(); // 비회원은 빈 맵 처리
+    }
+
     List<ChapterListResponse.ChapterSummaryDto> chapterDtos = chapters.stream()
         .map(chapter -> new ChapterListResponse.ChapterSummaryDto(
             chapter.getId(),
@@ -66,11 +70,11 @@ public class LearningService {
   // 2. 단일 챕터 학습 데이터 조회 (진행도 자동 생성 포함)
   @Transactional
   public ChapterLearningResponse getChapterLearningData(Long userId, Long chapterId) {
-    // 진행도가 없으면 새로 생성 (최초 진입)
     // 챕터 기본 정보 조회
     Chapter chapter = chapterRepository.findById(chapterId)
         .orElseThrow(() -> new BusinessException(LearningErrorCode.CHAPTER_NOT_FOUND));
 
+    // 진행도가 없으면 새로 생성 (최초 진입) or 유저의 진행도 정보를 DB에서 꺼내옴
     LearningProgress progress = progressRepository.findByUserIdAndChapterId(userId, chapterId)
         .orElseGet(() -> progressRepository.save(new LearningProgress(userId, chapterId)));
 
@@ -82,6 +86,11 @@ public class LearningService {
     List<QuizInfo> quizzes = quizRepository.findByChapterIdOrderBySequenceAsc(chapterId).stream()
         .map(QuizInfo::withoutAnswer)
         .collect(Collectors.toList());
+
+    // 이어서 풀 문제 번호(resumeQuizSequence) 계산 로직
+    Integer nextQuizSequence = (progress.getStatus() == ProgressStatus.READY)
+        ? null
+        : progress.getLastSolvedQuizSequence() + 1;
 
     // List 형태로 coreKeywords 를 바꿔줌
     List<String> keywordList = Arrays.stream(chapter.getCoreKeywords().split(","))
@@ -95,7 +104,7 @@ public class LearningService {
         .currentGoal(chapter.getCurrentGoal())
         .coreKeywords(keywordList)
         .currentStatus(progress.getStatus())
-        .resumeQuizSequence(progress.getLastSolvedQuizSequence())
+        .resumeQuizSequence(nextQuizSequence) // 저장해둔 마지막 문제 번호 + 1 을 프론트엔드로 내려줌 (이어서 풀 문제 번호)
         .vocabs(vocabs)
         .quizzes(quizzes)
         .build();
@@ -105,36 +114,46 @@ public class LearningService {
   @Transactional
   public void completeVocabulary(Long userId, Long chapterId) {
     LearningProgress progress = progressRepository.findByUserIdAndChapterId(userId, chapterId)
-        .orElseThrow(() -> new IllegalArgumentException("진행도 정보가 없습니다."));
+        .orElseThrow(() -> new BusinessException(LearningErrorCode.PROGRESS_NOT_FOUND));
 
-    // 단어장을 다 봤으므로 퀴즈 진행 상태로 변경
     progress.startQuiz();
   }
 
   // 4. 퀴즈 제출 및 채점 (자동 저장)
   @Transactional
   public QuizSubmitResponse submitQuizAnswer(Long userId, Long chapterId, Long quizId, QuizSubmitRequest request) {
-    Quiz quiz = quizRepository.findById(quizId)
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 퀴즈입니다."));
+    // 방어 로직 추가: 답안이 비어있거나 null로 들어왔을 때 튕겨내기
+    if (request.getSelectedAnswer() == null || request.getSelectedAnswer().trim().isEmpty()) {
+      throw new BusinessException(LearningErrorCode.INVALID_QUIZ_SUBMISSION);
+    }
 
-    // 정답 비교
+    Quiz quiz = quizRepository.findById(quizId)
+        .orElseThrow(() -> new BusinessException(LearningErrorCode.QUIZ_NOT_FOUND));
+
+    // 유저가 보낸 답과 실제 정답 비교 (채점)
     boolean isCorrect = quiz.getCorrectAnswer().equals(request.getSelectedAnswer());
 
-    // 유저 답안 로깅
-    UserQuizAnswer answer = new UserQuizAnswer(userId, chapterId, quiz.getId(), request.getSelectedAnswer(), isCorrect);
-    answerRepository.save(answer);
+    UserQuizAnswer answer = new UserQuizAnswer(
+        userId,
+        chapterId,
+        quiz.getId(),
+        request.getSelectedAnswer(), // 유저가 고른 답
+        isCorrect                    // 정답 여부
+    );
+    answerRepository.save(answer);   // DB(user_quiz_answer 테이블)에 INSERT
 
-    // 진행도 업데이트 (이탈 시 여기부터 재개)
+    // 유저의 해당 챕터 진행도 정보를 불러옴
     LearningProgress progress = progressRepository.findByUserIdAndChapterId(userId, chapterId)
-        .orElseThrow(() -> new IllegalArgumentException("진행도 정보가 없습니다."));
+        .orElseThrow(() -> new BusinessException(LearningErrorCode.PROGRESS_NOT_FOUND));
 
     int totalQuizzes = quizRepository.countByChapterId(chapterId);
 
-    // 마지막 문제인지 확인 후 상태 업데이트
+    // 마지막 문제가 아니면 "진행 중" 상태와 함께 '방금 푼 문제 번호'를 저장함
     if (quiz.getSequence() >= totalQuizzes) {
       progress.updateProgress(quiz.getSequence(), ProgressStatus.COMPLETED);
       // TODO: (선택) 보상(바이트) 지급 로직을 여기에 추가할 수 있습니다.
     } else {
+      // 퀴즈를 풀다 나갔다면, DB에는 이 마지막 sequence 번호가 남아있게 됨
       progress.updateProgress(quiz.getSequence(), ProgressStatus.QUIZ_IN_PROGRESS);
     }
 

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
@@ -19,8 +19,11 @@ import com.ogi1t.bitelearn.domain.learning.repository.LearningProgressRepository
 import com.ogi1t.bitelearn.domain.learning.repository.QuizRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.VocabularyRepository;
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
 import com.ogi1t.bitelearn.global.exception.BusinessException;
 import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
+import com.ogi1t.bitelearn.global.exception.domain.UserErrorCode;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +43,7 @@ public class LearningService {
   private final QuizRepository quizRepository;
   private final LearningProgressRepository progressRepository;
   private final UserQuizAnswerRepository answerRepository;
+  private final UserRepository userRepository;
 
   // 1. 챕터 목록 조회
   public ChapterListResponse getChaptersByCategoryAndTopic(Long userId, Category category, Topic topic) {
@@ -153,7 +157,6 @@ public class LearningService {
     // 마지막 문제가 아니면 "진행 중" 상태와 함께 '방금 푼 문제 번호'를 저장함
     if (quiz.getSequence() >= totalQuizzes) {
       progress.updateProgress(quiz.getSequence(), ProgressStatus.COMPLETED);
-      // TODO: (선택) 보상(바이트) 지급 로직을 여기에 추가할 수 있습니다.
     } else {
       // 퀴즈를 풀다 나갔다면, DB에는 이 마지막 sequence 번호가 남아있게 됨
       progress.updateProgress(quiz.getSequence(), ProgressStatus.QUIZ_IN_PROGRESS);
@@ -163,21 +166,44 @@ public class LearningService {
   }
 
   // 5. 최종 결과 조회
+  @Transactional
   public ChapterResultResponse getChapterResult(Long userId, Long chapterId) {
     int totalQuizzes = quizRepository.countByChapterId(chapterId);
     int correctQuizzes = answerRepository.countLatestCorrectAnswers(userId, chapterId);
+    int incorrectQuizzes = totalQuizzes - correctQuizzes;
 
-    // 0으로 나누기 방지
     int accuracyRate = totalQuizzes > 0 ? (int) Math.round(((double) correctQuizzes / totalQuizzes) * 100) : 0;
 
-    // 임시 보상 로직 (기획에 따라 변경 가능)
-    int earnedBytes = accuracyRate >= 80 ? 500 : 100;
+    // 유저의 진행도 정보와 회원 정보 가져오기
+    LearningProgress progress = progressRepository.findByUserIdAndChapterId(userId, chapterId)
+        .orElseThrow(() -> new BusinessException(LearningErrorCode.PROGRESS_NOT_FOUND));
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+    final int earnedBytes;
+    final int lostBytes;
+
+    if (progress.isRewarded()) {
+      // 이미 보상을 받은 경우 둘 다 0 처리 (재대입 없이 여기서 최초 할당)
+      earnedBytes = 0;
+      lostBytes = 0;
+    } else {
+      earnedBytes = correctQuizzes * 50;
+      lostBytes = incorrectQuizzes * -20;
+
+      user.addBytes(earnedBytes + lostBytes);
+      progress.markAsRewarded();
+    }
 
     return ChapterResultResponse.builder()
         .correctCount(correctQuizzes)
         .totalCount(totalQuizzes)
         .accuracyRate(accuracyRate)
         .earnedBytes(earnedBytes)
+        .lostBytes(lostBytes)
+        .currentLevel(user.getLevel())
+        .currentTotalBytes(user.getTotalBytes())
         .build();
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
@@ -165,7 +165,7 @@ public class LearningService {
   // 5. 최종 결과 조회
   public ChapterResultResponse getChapterResult(Long userId, Long chapterId) {
     int totalQuizzes = quizRepository.countByChapterId(chapterId);
-    int correctQuizzes = answerRepository.countByUserIdAndChapterIdAndIsCorrectTrue(userId, chapterId);
+    int correctQuizzes = answerRepository.countLatestCorrectAnswers(userId, chapterId);
 
     // 0으로 나누기 방지
     int accuracyRate = totalQuizzes > 0 ? (int) Math.round(((double) correctQuizzes / totalQuizzes) * 100) : 0;

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
@@ -19,6 +19,8 @@ import com.ogi1t.bitelearn.domain.learning.repository.LearningProgressRepository
 import com.ogi1t.bitelearn.domain.learning.repository.QuizRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.VocabularyRepository;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -65,6 +67,10 @@ public class LearningService {
   @Transactional
   public ChapterLearningResponse getChapterLearningData(Long userId, Long chapterId) {
     // 진행도가 없으면 새로 생성 (최초 진입)
+    // 챕터 기본 정보 조회
+    Chapter chapter = chapterRepository.findById(chapterId)
+        .orElseThrow(() -> new BusinessException(LearningErrorCode.CHAPTER_NOT_FOUND));
+
     LearningProgress progress = progressRepository.findByUserIdAndChapterId(userId, chapterId)
         .orElseGet(() -> progressRepository.save(new LearningProgress(userId, chapterId)));
 
@@ -77,7 +83,17 @@ public class LearningService {
         .map(QuizInfo::withoutAnswer)
         .collect(Collectors.toList());
 
+    // List 형태로 coreKeywords 를 바꿔줌
+    List<String> keywordList = Arrays.stream(chapter.getCoreKeywords().split(","))
+        .map(String::trim)
+        .collect(Collectors.toList());
+
     return ChapterLearningResponse.builder()
+        .chapterTitle(chapter.getTitle())
+        .prologueSubtitle(chapter.getPrologueSubtitle())
+        .prologueContent(chapter.getPrologueContent())
+        .currentGoal(chapter.getCurrentGoal())
+        .coreKeywords(keywordList)
         .currentStatus(progress.getStatus())
         .resumeQuizSequence(progress.getLastSolvedQuizSequence())
         .vocabs(vocabs)

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
@@ -98,6 +98,8 @@ public class LearningService {
         .collect(Collectors.toList());
 
     return ChapterLearningResponse.builder()
+        .category(chapter.getCategory().name())
+        .topic(chapter.getTopic().name())
         .chapterTitle(chapter.getTitle())
         .prologueSubtitle(chapter.getPrologueSubtitle())
         .prologueContent(chapter.getPrologueContent())

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
@@ -1,6 +1,7 @@
 package com.ogi1t.bitelearn.domain.learning.service;
 
 import com.ogi1t.bitelearn.domain.learning.dto.request.QuizSubmitRequest;
+import com.ogi1t.bitelearn.domain.learning.dto.response.CategoryTopicResponse;
 import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterLearningResponse;
 import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterListResponse;
 import com.ogi1t.bitelearn.domain.learning.dto.response.ChapterResultResponse;
@@ -45,7 +46,31 @@ public class LearningService {
   private final UserQuizAnswerRepository answerRepository;
   private final UserRepository userRepository;
 
-  // 1. 챕터 목록 조회
+  /**
+   * 전체 카테고리(대분류) 및 토픽(중분류) 목록 조회
+   */
+  public List<CategoryTopicResponse> getAllCategoriesAndTopics() {
+    return Arrays.stream(Category.values())
+        .map(category -> {
+          List<CategoryTopicResponse.TopicDto> topicDtos = category.getTopics().stream()
+              .map(topic -> new CategoryTopicResponse.TopicDto(
+                  topic.name(),
+                  topic.getDescription()
+              ))
+              .collect(Collectors.toList());
+
+          return CategoryTopicResponse.builder()
+              .categoryCode(category.name())
+              .categoryName(category.getDescription())
+              .topics(topicDtos)
+              .build();
+        })
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * 챕터 목록 조회
+   */
   public ChapterListResponse getChaptersByCategoryAndTopic(Long userId, Category category, Topic topic) {
     List<Chapter> chapters = chapterRepository.findByCategoryAndTopicOrderBySequenceAsc(category, topic);
     List<Long> chapterIds = chapters.stream().map(Chapter::getId).collect(Collectors.toList());
@@ -71,7 +96,9 @@ public class LearningService {
     return new ChapterListResponse(chapterDtos);
   }
 
-  // 2. 단일 챕터 학습 데이터 조회 (진행도 자동 생성 포함)
+  /**
+   * 단일 챕터 학습 데이터 조회 (진행도 자동 생성 포함)
+   */
   @Transactional
   public ChapterLearningResponse getChapterLearningData(Long userId, Long chapterId) {
     // 챕터 기본 정보 조회
@@ -117,7 +144,9 @@ public class LearningService {
         .build();
   }
 
-  // 3. 단어장 완료 처리 (상태 변경)
+  /**
+   * 단어장 완료 처리 (상태 변경)
+   */
   @Transactional
   public void completeVocabulary(Long userId, Long chapterId) {
     LearningProgress progress = progressRepository.findByUserIdAndChapterId(userId, chapterId)
@@ -126,7 +155,9 @@ public class LearningService {
     progress.startQuiz();
   }
 
-  // 4. 퀴즈 제출 및 채점 (자동 저장)
+  /**
+   * 퀴즈 제출 및 채점 (자동 저장)
+   */
   @Transactional
   public QuizSubmitResponse submitQuizAnswer(Long userId, Long chapterId, Long quizId, QuizSubmitRequest request) {
     // 방어 로직 추가: 답안이 비어있거나 null로 들어왔을 때 튕겨내기
@@ -166,7 +197,9 @@ public class LearningService {
     return new QuizSubmitResponse(isCorrect, quiz.getCorrectAnswer(), quiz.getExplanation(), progress.getStatus());
   }
 
-  // 5. 최종 결과 조회
+  /**
+   * 최종 결과 조회
+   */
   @Transactional
   public ChapterResultResponse getChapterResult(Long userId, Long chapterId) {
     int totalQuizzes = quizRepository.countByChapterId(chapterId);

--- a/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/learning/service/LearningService.java
@@ -113,6 +113,7 @@ public class LearningService {
         .resumeQuizSequence(nextQuizSequence) // 저장해둔 마지막 문제 번호 + 1 을 프론트엔드로 내려줌 (이어서 풀 문제 번호)
         .vocabs(vocabs)
         .quizzes(quizzes)
+        .closingMessage(chapter.getClosingMessage())
         .build();
   }
 

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/controller/NoteController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/controller/NoteController.java
@@ -20,13 +20,14 @@ public class NoteController {
 
   private final NoteService noteService;
 
-  @Operation(summary = "오답 노트 목록 조회", description = "틀린 문제(오답) 목록을 카테고리별로 조회합니다.")
+  @Operation(summary = "오답 노트 목록 조회 (무한 스크롤)", description = "틀린 문제(오답) 목록을 카테고리별로 10개씩 조회합니다. 첫 요청 시 cursor는 비워두세요.")
   @GetMapping("/incorrect")
   public ResponseEntity<IncorrectNoteListResponse> getIncorrectNotes(
       @RequestParam(required = false) Category category, // 카테고리가 없으면 전체 조회
+      @RequestParam(required = false) Long cursor,
       @AuthenticationPrincipal CustomPrincipal principal) {
 
-    IncorrectNoteListResponse response = noteService.getIncorrectNoteList(principal.getUserId(), category);
+    IncorrectNoteListResponse response = noteService.getIncorrectNoteList(principal.getUserId(), category, cursor);
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/controller/NoteController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/controller/NoteController.java
@@ -1,0 +1,42 @@
+package com.ogi1t.bitelearn.domain.note.controller;
+
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
+import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteDetailResponse;
+import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse;
+import com.ogi1t.bitelearn.domain.note.service.NoteService;
+import com.ogi1t.bitelearn.global.security.CustomPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Note API", description = "오답 노트 및 저장한 글 API")
+@RestController
+@RequestMapping("/notes")
+@RequiredArgsConstructor
+public class NoteController {
+
+  private final NoteService noteService;
+
+  @Operation(summary = "오답 노트 목록 조회", description = "틀린 문제(오답) 목록을 카테고리별로 조회합니다.")
+  @GetMapping("/incorrect")
+  public ResponseEntity<IncorrectNoteListResponse> getIncorrectNotes(
+      @RequestParam(required = false) Category category, // 카테고리가 없으면 전체 조회
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    IncorrectNoteListResponse response = noteService.getIncorrectNoteList(principal.getUserId(), category);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "오답 노트 상세 조회", description = "특정 오답 노트의 문제 내용, 내 오답, 정답, 해설을 조회합니다.")
+  @GetMapping("/incorrect/{noteId}")
+  public ResponseEntity<IncorrectNoteDetailResponse> getIncorrectNoteDetail(
+      @PathVariable Long noteId,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    IncorrectNoteDetailResponse response = noteService.getIncorrectNoteDetail(principal.getUserId(), noteId);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteDetailResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteDetailResponse.java
@@ -1,0 +1,27 @@
+package com.ogi1t.bitelearn.domain.note.dto.response;
+
+import com.ogi1t.bitelearn.domain.learning.dto.info.QuizInfo;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class IncorrectNoteDetailResponse {
+  // 유저 글로벌 정보
+  private int totalCount;
+  private int totalBytes;
+
+  // 오답 노트 메타 정보
+  private Long noteId;
+  private Long chapterId;
+  private LocalDateTime createdAt;
+
+  // 내가 제출한 오답과 실제 정답/해설
+  private String userAnswer;
+  private String correctAnswer;
+  private String explanation;
+
+  // 학습 API에서 쓰던 QuizInfo 구조를 그대로 재사용
+  private QuizInfo quiz;
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteDetailResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteDetailResponse.java
@@ -15,7 +15,6 @@ public class IncorrectNoteDetailResponse {
   // 오답 노트 메타 정보
   private Long noteId;
   private Long chapterId;
-  private String chapterTitle;
   private LocalDateTime createdAt;
 
   // 내가 제출한 오답과 실제 정답/해설

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteDetailResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteDetailResponse.java
@@ -15,6 +15,7 @@ public class IncorrectNoteDetailResponse {
   // 오답 노트 메타 정보
   private Long noteId;
   private Long chapterId;
+  private String chapterTitle;
   private LocalDateTime createdAt;
 
   // 내가 제출한 오답과 실제 정답/해설

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteListResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteListResponse.java
@@ -15,6 +15,10 @@ public class IncorrectNoteListResponse {
   private int totalBytes;
   private List<IncorrectNoteDto> notes;
 
+  // 무한 스크롤을 위한 필드 추가
+  private Long nextCursor;
+  private boolean hasNext;
+
   @Getter
   @AllArgsConstructor
   public static class IncorrectNoteDto {

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteListResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteListResponse.java
@@ -27,6 +27,7 @@ public class IncorrectNoteListResponse {
     private Long quizId;
     private Category category;
     private Topic topic;
+    private Integer chapterSequence;
     private String questionTitle;
     private String userAnswer;
     private String correctAnswer;

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteListResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteListResponse.java
@@ -1,0 +1,31 @@
+package com.ogi1t.bitelearn.domain.note.dto.response;
+
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Topic;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class IncorrectNoteListResponse {
+  private int totalCount;
+  private int totalBytes;
+  private List<IncorrectNoteDto> notes;
+
+  @Getter
+  @AllArgsConstructor
+  public static class IncorrectNoteDto {
+    private Long noteId;
+    private Long chapterId;
+    private Long quizId;
+    private Category category;
+    private Topic topic;
+    private String questionTitle;
+    private String userAnswer;
+    private String correctAnswer;
+    private LocalDateTime createdAt;
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteListResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/dto/response/IncorrectNoteListResponse.java
@@ -27,6 +27,7 @@ public class IncorrectNoteListResponse {
     private Long quizId;
     private Category category;
     private Topic topic;
+    private String chapterTitle;
     private Integer chapterSequence;
     private String questionTitle;
     private String userAnswer;

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
@@ -26,7 +26,6 @@ public class NoteService {
 
   private final UserQuizAnswerRepository answerRepository;
   private final QuizRepository quizRepository;
-  // private final UserRepository userRepository; // 추후 보유 바이트 연동 시 주입
   private final ChapterRepository chapterRepository;
 
   // 1. 오답 노트 목록 조회 (무한 스크롤)
@@ -107,7 +106,7 @@ public class NoteService {
         .userAnswer(note.getSelectedAnswer())
         .correctAnswer(quiz.getCorrectAnswer())
         .explanation(quiz.getExplanation())
-        .quiz(reusableQuizInfo) // 프론트엔드가 그대로 재사용할 퀴즈 컴포넌트 데이터!
+        .quiz(reusableQuizInfo)
         .build();
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
@@ -10,8 +10,11 @@ import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
 import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteDetailResponse;
 import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse;
 import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse.IncorrectNoteDto;
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
 import com.ogi1t.bitelearn.global.exception.BusinessException;
 import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
+import com.ogi1t.bitelearn.global.exception.domain.UserErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -27,13 +30,17 @@ public class NoteService {
   private final UserQuizAnswerRepository answerRepository;
   private final QuizRepository quizRepository;
   private final ChapterRepository chapterRepository;
+  private final UserRepository userRepository;
 
   // 1. 오답 노트 목록 조회 (무한 스크롤)
   public IncorrectNoteListResponse getIncorrectNoteList(Long userId, Category category, Long cursor) {
     // 총 오답 개수
     int totalCount = answerRepository.countByUserIdAndIsCorrectFalse(userId);
-    // TODO: 유저 보유 바이트 연동 로직 (임시 1250 바이트)
-    int totalBytes = 1250;
+
+    // 실제 유저 정보 조회 및 보유 바이트 연동
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    int totalBytes = user.getTotalBytes();
 
     // 처음 조회 시(cursor가 null) 가장 큰 값을 주어 최신 데이터부터 가져오게 함
     Long actualCursor = (cursor == null) ? Long.MAX_VALUE : cursor;
@@ -89,11 +96,15 @@ public class NoteService {
         .map(chapter -> chapter.getTitle())
         .orElse("알 수 없는 챕터");
 
-    // 총 오답 개수 및 보유 바이트 (상세 화면 상단에도 그려줘야 하므로)
+    // 총 오답 개수 및 보유 바이트
     int totalCount = answerRepository.countByUserIdAndIsCorrectFalse(userId);
-    int totalBytes = 1250;
 
-    // 기존 Learning 도메인의 QuizInfo 재사용 (정답 제외 데이터 세팅)
+    // 실제 유저 정보 조회 및 보유 바이트 연동
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    int totalBytes = user.getTotalBytes();
+
+    // 기존 Learning 도메인의 QuizInfo 재사용
     QuizInfo reusableQuizInfo = QuizInfo.withoutAnswer(quiz);
 
     return IncorrectNoteDetailResponse.builder()

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
@@ -13,6 +13,7 @@ import com.ogi1t.bitelearn.domain.user.entity.User;
 import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
 import com.ogi1t.bitelearn.global.exception.BusinessException;
 import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
+import com.ogi1t.bitelearn.global.exception.domain.NoteErrorCode;
 import com.ogi1t.bitelearn.global.exception.domain.UserErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -78,11 +79,11 @@ public class NoteService {
   public IncorrectNoteDetailResponse getIncorrectNoteDetail(Long userId, Long noteId) {
     // 오답 기록 조회
     UserQuizAnswer note = answerRepository.findById(noteId)
-        .orElseThrow(() -> new BusinessException(LearningErrorCode.NOTE_NOT_FOUND));
+        .orElseThrow(() -> new BusinessException(NoteErrorCode.NOTE_NOT_FOUND));
 
     // 권한 검증 (내 오답 노트가 맞는지)
     if (!note.getUserId().equals(userId)) {
-      throw new BusinessException(LearningErrorCode.UNAUTHORIZED_ACCESS);
+      throw new BusinessException(NoteErrorCode.UNAUTHORIZED_NOTE_ACCESS);
     }
 
     // 퀴즈 원본 데이터 조회

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
@@ -13,6 +13,8 @@ import com.ogi1t.bitelearn.global.exception.BusinessException;
 import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,26 +27,44 @@ public class NoteService {
   private final QuizRepository quizRepository;
   // private final UserRepository userRepository; // 추후 보유 바이트 연동 시 주입
 
-  // 1. 오답 노트 목록 조회
-  public IncorrectNoteListResponse getIncorrectNoteList(Long userId, Category category) {
+  // 1. 오답 노트 목록 조회 (무한 스크롤)
+  public IncorrectNoteListResponse getIncorrectNoteList(Long userId, Category category, Long cursor) {
     // 총 오답 개수
     int totalCount = answerRepository.countByUserIdAndIsCorrectFalse(userId);
     // TODO: 유저 보유 바이트 연동 로직 (임시 1250 바이트)
     int totalBytes = 1250;
 
+    // 처음 조회 시(cursor가 null) 가장 큰 값을 주어 최신 데이터부터 가져오게 함
+    Long actualCursor = (cursor == null) ? Long.MAX_VALUE : cursor;
+
+    // 다음 페이지가 있는지 확인하기 위해 요청된 10개보다 1개 더 많은 11개를 조회합니다!
+    Pageable limit = PageRequest.of(0, 11);
+
     List<IncorrectNoteDto> notes;
     if (category == null) {
       // 카테고리가 없으면 전체 오답 노트 최신순 조회
-      notes = answerRepository.findAllIncorrectNotesByUserId(userId);
+      notes = answerRepository.findAllIncorrectNotesByCursor(userId, actualCursor, limit);
     } else {
       // 카테고리가 있으면 해당 카테고리만 필터링해서 조회
-      notes = answerRepository.findIncorrectNotesByUserIdAndCategory(userId, category);
+      notes = answerRepository.findIncorrectNotesByCategoryAndCursor(userId, category, actualCursor, limit);
+    }
+
+    boolean hasNext = false;
+    Long nextCursor = null;
+
+    // 조회된 결과가 11개라면 다음 페이지가 존재한다는 의미!
+    if (notes.size() > 10) {
+      hasNext = true;
+      notes = notes.subList(0, 10); // 프론트에는 10개만 잘라서 내려줌
+      nextCursor = notes.get(9).getNoteId(); // 마지막 10번째 데이터의 ID를 다음 커서로 지정
     }
 
     return IncorrectNoteListResponse.builder()
         .totalCount(totalCount)
         .totalBytes(totalBytes)
         .notes(notes)
+        .nextCursor(nextCursor)
+        .hasNext(hasNext)
         .build();
   }
 

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
@@ -1,0 +1,85 @@
+package com.ogi1t.bitelearn.domain.note.service;
+
+import com.ogi1t.bitelearn.domain.learning.dto.info.QuizInfo;
+import com.ogi1t.bitelearn.domain.learning.entity.Quiz;
+import com.ogi1t.bitelearn.domain.learning.entity.UserQuizAnswer;
+import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
+import com.ogi1t.bitelearn.domain.learning.repository.QuizRepository;
+import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
+import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteDetailResponse;
+import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse;
+import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteListResponse.IncorrectNoteDto;
+import com.ogi1t.bitelearn.global.exception.BusinessException;
+import com.ogi1t.bitelearn.global.exception.domain.LearningErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoteService {
+
+  private final UserQuizAnswerRepository answerRepository;
+  private final QuizRepository quizRepository;
+  // private final UserRepository userRepository; // 추후 보유 바이트 연동 시 주입
+
+  // 1. 오답 노트 목록 조회
+  public IncorrectNoteListResponse getIncorrectNoteList(Long userId, Category category) {
+    // 총 오답 개수
+    int totalCount = answerRepository.countByUserIdAndIsCorrectFalse(userId);
+    // TODO: 유저 보유 바이트 연동 로직 (임시 1250 바이트)
+    int totalBytes = 1250;
+
+    List<IncorrectNoteDto> notes;
+    if (category == null) {
+      // 카테고리가 없으면 전체 오답 노트 최신순 조회
+      notes = answerRepository.findAllIncorrectNotesByUserId(userId);
+    } else {
+      // 카테고리가 있으면 해당 카테고리만 필터링해서 조회
+      notes = answerRepository.findIncorrectNotesByUserIdAndCategory(userId, category);
+    }
+
+    return IncorrectNoteListResponse.builder()
+        .totalCount(totalCount)
+        .totalBytes(totalBytes)
+        .notes(notes)
+        .build();
+  }
+
+  // 2. 오답 노트 상세 조회
+  public IncorrectNoteDetailResponse getIncorrectNoteDetail(Long userId, Long noteId) {
+    // 오답 기록 조회
+    UserQuizAnswer note = answerRepository.findById(noteId)
+        .orElseThrow(() -> new BusinessException(LearningErrorCode.NOTE_NOT_FOUND));
+
+    // 권한 검증 (내 오답 노트가 맞는지)
+    if (!note.getUserId().equals(userId)) {
+      throw new BusinessException(LearningErrorCode.UNAUTHORIZED_ACCESS);
+    }
+
+    // 퀴즈 원본 데이터 조회
+    Quiz quiz = quizRepository.findById(note.getQuizId())
+        .orElseThrow(() -> new BusinessException(LearningErrorCode.QUIZ_NOT_FOUND));
+
+    // 총 오답 개수 및 보유 바이트 (상세 화면 상단에도 그려줘야 하므로)
+    int totalCount = answerRepository.countByUserIdAndIsCorrectFalse(userId);
+    int totalBytes = 1250;
+
+    // 기존 Learning 도메인의 QuizInfo 재사용 (정답 제외 데이터 세팅)
+    QuizInfo reusableQuizInfo = QuizInfo.withoutAnswer(quiz);
+
+    return IncorrectNoteDetailResponse.builder()
+        .totalCount(totalCount)
+        .totalBytes(totalBytes)
+        .noteId(note.getId())
+        .chapterId(note.getChapterId())
+        .createdAt(note.getCreatedAt())
+        .userAnswer(note.getSelectedAnswer())
+        .correctAnswer(quiz.getCorrectAnswer())
+        .explanation(quiz.getExplanation())
+        .quiz(reusableQuizInfo) // 프론트엔드가 그대로 재사용할 퀴즈 컴포넌트 데이터!
+        .build();
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
@@ -4,7 +4,6 @@ import com.ogi1t.bitelearn.domain.learning.dto.info.QuizInfo;
 import com.ogi1t.bitelearn.domain.learning.entity.Quiz;
 import com.ogi1t.bitelearn.domain.learning.entity.UserQuizAnswer;
 import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
-import com.ogi1t.bitelearn.domain.learning.repository.ChapterRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.QuizRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
 import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteDetailResponse;
@@ -29,7 +28,6 @@ public class NoteService {
 
   private final UserQuizAnswerRepository answerRepository;
   private final QuizRepository quizRepository;
-  private final ChapterRepository chapterRepository;
   private final UserRepository userRepository;
 
   // 1. 오답 노트 목록 조회 (무한 스크롤)
@@ -91,11 +89,6 @@ public class NoteService {
     Quiz quiz = quizRepository.findById(note.getQuizId())
         .orElseThrow(() -> new BusinessException(LearningErrorCode.QUIZ_NOT_FOUND));
 
-    // 챕터 아이디로 챕터 제목을 가져오기
-    String chapterTitle = chapterRepository.findById(note.getChapterId())
-        .map(chapter -> chapter.getTitle())
-        .orElse("알 수 없는 챕터");
-
     // 총 오답 개수 및 보유 바이트
     int totalCount = answerRepository.countByUserIdAndIsCorrectFalse(userId);
 
@@ -112,7 +105,6 @@ public class NoteService {
         .totalBytes(totalBytes)
         .noteId(note.getId())
         .chapterId(note.getChapterId())
-        .chapterTitle(chapterTitle)
         .createdAt(note.getCreatedAt())
         .userAnswer(note.getSelectedAnswer())
         .correctAnswer(quiz.getCorrectAnswer())

--- a/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/note/service/NoteService.java
@@ -4,6 +4,7 @@ import com.ogi1t.bitelearn.domain.learning.dto.info.QuizInfo;
 import com.ogi1t.bitelearn.domain.learning.entity.Quiz;
 import com.ogi1t.bitelearn.domain.learning.entity.UserQuizAnswer;
 import com.ogi1t.bitelearn.domain.learning.entity.enums.Category;
+import com.ogi1t.bitelearn.domain.learning.repository.ChapterRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.QuizRepository;
 import com.ogi1t.bitelearn.domain.learning.repository.UserQuizAnswerRepository;
 import com.ogi1t.bitelearn.domain.note.dto.response.IncorrectNoteDetailResponse;
@@ -26,6 +27,7 @@ public class NoteService {
   private final UserQuizAnswerRepository answerRepository;
   private final QuizRepository quizRepository;
   // private final UserRepository userRepository; // 추후 보유 바이트 연동 시 주입
+  private final ChapterRepository chapterRepository;
 
   // 1. 오답 노트 목록 조회 (무한 스크롤)
   public IncorrectNoteListResponse getIncorrectNoteList(Long userId, Category category, Long cursor) {
@@ -83,6 +85,11 @@ public class NoteService {
     Quiz quiz = quizRepository.findById(note.getQuizId())
         .orElseThrow(() -> new BusinessException(LearningErrorCode.QUIZ_NOT_FOUND));
 
+    // 챕터 아이디로 챕터 제목을 가져오기
+    String chapterTitle = chapterRepository.findById(note.getChapterId())
+        .map(chapter -> chapter.getTitle())
+        .orElse("알 수 없는 챕터");
+
     // 총 오답 개수 및 보유 바이트 (상세 화면 상단에도 그려줘야 하므로)
     int totalCount = answerRepository.countByUserIdAndIsCorrectFalse(userId);
     int totalBytes = 1250;
@@ -95,6 +102,7 @@ public class NoteService {
         .totalBytes(totalBytes)
         .noteId(note.getId())
         .chapterId(note.getChapterId())
+        .chapterTitle(chapterTitle)
         .createdAt(note.getCreatedAt())
         .userAnswer(note.getSelectedAnswer())
         .correctAnswer(quiz.getCorrectAnswer())

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/controller/UserController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.ogi1t.bitelearn.domain.user.controller;
+
+import com.ogi1t.bitelearn.domain.user.dto.request.NicknameUpdateRequest;
+import com.ogi1t.bitelearn.domain.user.dto.response.UserResponse;
+import com.ogi1t.bitelearn.domain.user.service.UserService;
+import com.ogi1t.bitelearn.global.security.CustomPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User API", description = "유저 정보 조회 및 수정")
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+  private final UserService userService;
+
+  @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 상세 정보를 조회합니다.")
+  @GetMapping("/me")
+  public ResponseEntity<UserResponse> getMyInfo(@AuthenticationPrincipal CustomPrincipal principal) {
+    // principal.getUserId()는 우리가 만든 CustomPrincipal에서 가져옴 (JWT 파싱 결과)
+    UserResponse response = userService.getMyInfo(principal.getUserId());
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "닉네임 수정", description = "로그인한 사용자의 닉네임을 변경합니다. (중복 불가)")
+  @PatchMapping("/me/nickname")
+  public ResponseEntity<String> updateNickname(@AuthenticationPrincipal CustomPrincipal principal, @RequestBody NicknameUpdateRequest request) {
+    userService.updateNickname(principal.getUserId(), request);
+    return ResponseEntity.ok("닉네임이 성공적으로 변경되었습니다.");
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/controller/UserController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/controller/UserController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "User API", description = "유저 정보 조회 및 수정")
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/controller/UserController.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/controller/UserController.java
@@ -37,4 +37,11 @@ public class UserController {
     userService.updateNickname(principal.getUserId(), request);
     return ResponseEntity.ok("닉네임이 성공적으로 변경되었습니다.");
   }
+
+  @Operation(summary = "온보딩 완료 처리", description = "로그인한 사용자의 온보딩 완료 상태를 true로 변경합니다.")
+  @PatchMapping("/me/onboarding")
+  public ResponseEntity<String> completeOnboarding(@AuthenticationPrincipal CustomPrincipal principal) {
+    userService.completeOnboarding(principal.getUserId());
+    return ResponseEntity.ok("온보딩이 완료 처리되었습니다.");
+  }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/dto/request/NicknameUpdateRequest.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/dto/request/NicknameUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.ogi1t.bitelearn.domain.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NicknameUpdateRequest {
+  private String nickname;
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/dto/response/UserResponse.java
@@ -1,5 +1,6 @@
 package com.ogi1t.bitelearn.domain.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ogi1t.bitelearn.domain.auth.entity.enums.ProviderType;
 import com.ogi1t.bitelearn.domain.user.entity.User;
 import lombok.Builder;
@@ -13,6 +14,7 @@ public class UserResponse {
   private String email;
   private String nickname;
   private ProviderType providerType;
+  private Boolean isOnboardingCompleted;
 
   public static UserResponse from(User user) {
     return UserResponse.builder()
@@ -20,6 +22,7 @@ public class UserResponse {
         .email(user.getEmail())
         .nickname(user.getNickname())
         .providerType(user.getProviderType())
+        .isOnboardingCompleted(user.isOnboardingCompleted())
         .build();
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,25 @@
+package com.ogi1t.bitelearn.domain.user.dto.response;
+
+import com.ogi1t.bitelearn.domain.auth.entity.enums.ProviderType;
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserResponse {
+
+  private Long id;
+  private String email;
+  private String nickname;
+  private ProviderType providerType;
+
+  public static UserResponse from(User user) {
+    return UserResponse.builder()
+        .id(user.getId())
+        .email(user.getEmail())
+        .nickname(user.getNickname())
+        .providerType(user.getProviderType())
+        .build();
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/dto/response/UserResponse.java
@@ -1,8 +1,8 @@
 package com.ogi1t.bitelearn.domain.user.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ogi1t.bitelearn.domain.auth.entity.enums.ProviderType;
 import com.ogi1t.bitelearn.domain.user.entity.User;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,13 +16,20 @@ public class UserResponse {
   private ProviderType providerType;
   private Boolean isOnboardingCompleted;
 
-  public static UserResponse from(User user) {
-    return UserResponse.builder()
-        .id(user.getId())
-        .email(user.getEmail())
-        .nickname(user.getNickname())
-        .providerType(user.getProviderType())
-        .isOnboardingCompleted(user.isOnboardingCompleted())
-        .build();
+  private Integer level;
+  private Integer totalBytes;
+  private RecentLearningDto recentLearning;
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  public static class RecentLearningDto {
+    private String categoryCode;  // 예: "REAL_ESTATE_HOUSING"
+    private String categoryName;  // 예: "부동산 · 주거"
+    private String topicCode;     // 예: "MONTHLY_RENT"
+    private String topicName;     // 예: "월세"
+    private String chapterTitle;  // 예: "내 소중한 돈을 사수하라! 💸"
+    private Long chapterId;       // 예: 3
+    private Integer progressRate; // 예: 50 (진행률 %)
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/entity/User.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/entity/User.java
@@ -56,8 +56,18 @@ public class User {
   @LastModifiedDate
   private LocalDateTime updatedAt;
 
+  // 온보딩 완료 여부 추가 (기본값 false)
+  @Column(nullable = false)
+  @Builder.Default
+  private boolean isOnboardingCompleted = false;
+
   // 닉네임 변경 편의 메서드
   public void updateNickname(String newNickname) {
     this.nickname = newNickname;
+  }
+
+  // 온보딩 완료 편의 메서드 추가
+  public void completeOnboarding() {
+    this.isOnboardingCompleted = true;
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/entity/User.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/entity/User.java
@@ -61,6 +61,7 @@ public class User {
   @Builder.Default
   private boolean isOnboardingCompleted = false;
 
+  @Builder.Default
   @Column(nullable = false)
   private int totalBytes = 0; // 유저가 보유한 총 바이트 (기본값 0)
 

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/entity/User.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/entity/User.java
@@ -61,6 +61,30 @@ public class User {
   @Builder.Default
   private boolean isOnboardingCompleted = false;
 
+  @Column(nullable = false)
+  private int totalBytes = 0; // 유저가 보유한 총 바이트 (기본값 0)
+
+  // 바이트 적립 메서드
+  public void addBytes(int bytes) {
+    this.totalBytes += bytes;
+
+    // 방어 로직: 총 보유 바이트가 0 밑으로 떨어지지 않게 막아줌
+    if (this.totalBytes < 0) {
+      this.totalBytes = 0;
+    }
+  }
+
+  // 현재 레벨 계산 메서드 (2000 / 4000 / 6000 기준)
+  public int getLevel() {
+    if (this.totalBytes < 2000) {
+      return 1;
+    } else if (this.totalBytes < 4000) {
+      return 2;
+    } else {
+      return 3; // 4000 이상은 모두 레벨 3 (만렙)
+    }
+  }
+
   // 닉네임 변경 편의 메서드
   public void updateNickname(String newNickname) {
     this.nickname = newNickname;

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/entity/User.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/entity/User.java
@@ -1,0 +1,63 @@
+package com.ogi1t.bitelearn.domain.user.entity;
+
+import com.ogi1t.bitelearn.domain.auth.entity.enums.ProviderType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class) // 생성시간 자동 주입
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true, length = 100)
+  private String email;
+
+  @Column(length = 255)
+  private String password;
+
+  @Column(nullable = false, unique = true, length = 50)
+  private String nickname;
+
+  @Column(length = 10)
+  private Integer age;
+
+  // ★ 소셜 로그인 종류 (GOOGLE, NAVER) 추가
+  @Enumerated(EnumType.STRING)
+  @Column(length = 20)
+  private ProviderType providerType;
+
+  @CreatedDate
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+  // 닉네임 변경 편의 메서드
+  public void updateNickname(String newNickname) {
+    this.nickname = newNickname;
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/repository/UserRepository.java
@@ -1,0 +1,40 @@
+package com.ogi1t.bitelearn.domain.user.repository;
+
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  // 이메일로 유저 찾기 (로그인 시 필요)
+  Optional<User> findByEmail(String email);
+
+  // 닉네임 중복 체크용 (회원가입 / 정보 수정 시 중복 방지)
+  boolean existsByNickname(String nickname);
+
+  // 이메일 중복 체크용 (회원가입 시 필요)
+  boolean existsByEmail(String email);
+
+  // ID와 닉네임 골라서 조회
+  @Query("SELECT u.id, u.nickname FROM User u WHERE u.id IN :ids")
+  List<Object[]> findIdAndNicknames(@Param("ids") Collection<Long> ids);
+
+  // 위 결과를 받아서 보기 편한 Map<ID, Nickname>으로 변환
+  default Map<Long, String> findNicknameMap(Collection<Long> ids) {
+    if (ids == null || ids.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    return findIdAndNicknames(ids).stream()
+        .collect(Collectors.toMap(
+            row -> (Long) row[0],    // Key: User ID
+            row -> (String) row[1]   // Value: Nickname
+        ));
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/service/UserService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/service/UserService.java
@@ -38,6 +38,13 @@ public class UserService {
     user.updateNickname(newNickname);
   }
 
+  // 3. 온보딩 완료 처리
+  @Transactional
+  public void completeOnboarding(Long userId) {
+    User user = findUserById(userId);
+    user.completeOnboarding(); // 상태를 true로 변경
+  }
+
   // 공통 유저 조회 메서드
   private User findUserById(Long userId) {
     return userRepository.findById(userId)

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/service/UserService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/service/UserService.java
@@ -1,0 +1,46 @@
+package com.ogi1t.bitelearn.domain.user.service;
+
+import com.ogi1t.bitelearn.domain.user.dto.request.NicknameUpdateRequest;
+import com.ogi1t.bitelearn.domain.user.dto.response.UserResponse;
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
+import com.ogi1t.bitelearn.global.exception.BusinessException;
+import com.ogi1t.bitelearn.global.exception.domain.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // 읽기 전용
+public class UserService {
+
+  private final UserRepository userRepository;
+
+  // 1. 내 정보 조회
+  public UserResponse getMyInfo(Long userId) {
+    User user = findUserById(userId);
+    return UserResponse.from(user);
+  }
+
+  // 2. 닉네임 수정
+  @Transactional // 쓰기 작업이므로 Transactional 필요
+  public void updateNickname(Long userId, NicknameUpdateRequest request) {
+    User user = findUserById(userId);
+    String newNickname = request.getNickname();
+
+    // 닉네임 중복 검사 (내 닉네임과 같으면 통과)
+    if (!user.getNickname().equals(newNickname) && userRepository.existsByNickname(newNickname)) {
+      throw new BusinessException(UserErrorCode.NICKNAME_DUPLICATION);
+    }
+
+    // 엔티티 변경 (Dirty Checking으로 자동 저장됨)
+    user.updateNickname(newNickname);
+  }
+
+  // 공통 유저 조회 메서드
+  private User findUserById(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/domain/user/service/UserService.java
+++ b/src/main/java/com/ogi1t/bitelearn/domain/user/service/UserService.java
@@ -1,26 +1,67 @@
 package com.ogi1t.bitelearn.domain.user.service;
 
+import com.ogi1t.bitelearn.domain.learning.entity.Chapter;
+import com.ogi1t.bitelearn.domain.learning.entity.LearningProgress;
+import com.ogi1t.bitelearn.domain.learning.repository.ChapterRepository;
+import com.ogi1t.bitelearn.domain.learning.repository.LearningProgressRepository;
+import com.ogi1t.bitelearn.domain.learning.repository.QuizRepository;
 import com.ogi1t.bitelearn.domain.user.dto.request.NicknameUpdateRequest;
 import com.ogi1t.bitelearn.domain.user.dto.response.UserResponse;
 import com.ogi1t.bitelearn.domain.user.entity.User;
 import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
 import com.ogi1t.bitelearn.global.exception.BusinessException;
 import com.ogi1t.bitelearn.global.exception.domain.UserErrorCode;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true) // 읽기 전용
+@Transactional(readOnly = true)
 public class UserService {
 
   private final UserRepository userRepository;
+  private final LearningProgressRepository progressRepository;
+  private final ChapterRepository chapterRepository;
+  private final QuizRepository quizRepository;
 
   // 1. 내 정보 조회
   public UserResponse getMyInfo(Long userId) {
     User user = findUserById(userId);
-    return UserResponse.from(user);
+
+    UserResponse.RecentLearningDto recentDto = progressRepository.findFirstByUserIdOrderByUpdatedAtDesc(userId)
+        .map(progress -> {
+
+          Chapter chapter = chapterRepository.findById(progress.getChapterId()).orElse(null);
+          if (chapter == null) return null;
+
+          int totalQuizzes = quizRepository.countByChapterId(chapter.getId());
+          int solvedQuizzes = progress.getLastSolvedQuizSequence();
+          int progressRate = (totalQuizzes == 0) ? 0 : (int) Math.round(((double) solvedQuizzes / totalQuizzes) * 100);
+
+          return UserResponse.RecentLearningDto.builder()
+              .categoryCode(chapter.getCategory().name())
+              .categoryName(chapter.getCategory().getDescription())
+              .topicCode(chapter.getTopic().name())
+              .topicName(chapter.getTopic().getDescription())
+              .chapterTitle(chapter.getTitle())
+              .chapterId(chapter.getId())
+              .progressRate(progressRate)
+              .build();
+        })
+        .orElse(null);
+
+    return UserResponse.builder()
+        .id(user.getId())
+        .email(user.getEmail())
+        .nickname(user.getNickname())
+        .providerType(user.getProviderType())
+        .isOnboardingCompleted(user.isOnboardingCompleted())
+        .level(user.getLevel())
+        .totalBytes(user.getTotalBytes())
+        .recentLearning(recentDto)
+        .build();
   }
 
   // 2. 닉네임 수정

--- a/src/main/java/com/ogi1t/bitelearn/global/config/JacksonConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/JacksonConfig.java
@@ -1,0 +1,20 @@
+package com.ogi1t.bitelearn.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class JacksonConfig {
+
+  @Bean
+  @Primary // 다른 ObjectMapper가 있더라도 이 설정을 우선 사용하도록 합니다.
+  public ObjectMapper objectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    // LocalDateTime 같은 날짜 타입을 처리하기 위한 모듈 등록
+    objectMapper.registerModule(new JavaTimeModule());
+    return objectMapper;
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -46,20 +47,22 @@ public class SecurityConfig {
 
         // 요청에 대한 권한 설정
         .authorizeHttpRequests(auth -> auth
+            // 챕터 목록 조회(GET)는 비회원(토큰 없음)도 접근 허용
+            .requestMatchers(HttpMethod.GET, "/learning/chapters").permitAll()
+
             // 인증 없이 접근 가능한 경로
             .requestMatchers(
                 "/index.html/**",
                 "/ws-stomp/**",
-                "/auth/**", // 소셜 관련 경로 허용
-                "/auth/**", // 소셜 관련 경로 허용
-                "/login/**", // 소셜 관련 경로 허용
-                "/oauth2/**", // 소셜 관련 경로 허용
-                "/oauth/**", // 소셜 관련 경로 허용
-                "/v3/api-docs/**", // 스웨거
-                "/swagger-ui/**", // 스웨거
-                "/swagger-ui.html") // 스웨거
+                "/auth/**",
+                "/login/**",
+                "/oauth2/**",
+                "/oauth/**",
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/swagger-ui.html"
+            ).permitAll()
             // 그 외 모든 요청은 인증 필요
-            .permitAll()
             .anyRequest().authenticated()
         )
 

--- a/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import com.ogi1t.bitelearn.domain.auth.service.CustomOAuth2UserService;
 import com.ogi1t.bitelearn.global.security.JwtAuthenticationFilter;
 import com.ogi1t.bitelearn.global.security.JwtProvider;
 import com.ogi1t.bitelearn.global.security.OAuth2SuccessHandler;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +17,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -33,9 +38,11 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
+        .cors(cors -> cors.configurationSource(corsConfigurationSource())) // ⭐ CORS 설정 적용
         .csrf(AbstractHttpConfigurer::disable) // REST API이므로 csrf 보안 필요 없음
         .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 로그인 비활성화
         .formLogin(AbstractHttpConfigurer::disable) // 기본 폼 로그인 비활성화
+        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
         // 세션을 사용하지 않음 (Stateless)
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -70,5 +77,33 @@ public class SecurityConfig {
         .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
 
     return http.build();
+  }
+
+  // ⭐ CORS 상세 설정 Bean 추가
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+
+    // 프론트엔드 로컬과 배포 주소 모두 허용
+    configuration.setAllowedOrigins(Arrays.asList(
+        "http://localhost:5173",
+        "https://bitelearn.vercel.app"
+    ));
+
+    // 허용할 HTTP 메서드
+    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+
+    // 허용할 헤더
+    configuration.setAllowedHeaders(List.of("*"));
+
+    // ⭐ 쿠키 등 인증 정보를 주고받을 수 있도록 허용
+    configuration.setAllowCredentials(true);
+
+    // 클라이언트가 응답 헤더 중 Authorization 등을 볼 수 있도록 노출
+    configuration.setExposedHeaders(Arrays.asList("Authorization", "Set-Cookie"));
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration); // 모든 API 경로에 이 설정 적용
+    return source;
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
@@ -42,10 +42,7 @@ public class SecurityConfig {
         .csrf(AbstractHttpConfigurer::disable) // REST API이므로 csrf 보안 필요 없음
         .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 로그인 비활성화
         .formLogin(AbstractHttpConfigurer::disable) // 기본 폼 로그인 비활성화
-        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-        // 세션을 사용하지 않음 (Stateless)
-        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션을 사용하지 않음 (Stateless)
 
         // 요청에 대한 권한 설정
         .authorizeHttpRequests(auth -> auth
@@ -57,6 +54,7 @@ public class SecurityConfig {
                 "/auth/**", // 소셜 관련 경로 허용
                 "/login/**", // 소셜 관련 경로 허용
                 "/oauth2/**", // 소셜 관련 경로 허용
+                "/oauth/**", // 소셜 관련 경로 허용
                 "/v3/api-docs/**", // 스웨거
                 "/swagger-ui/**", // 스웨거
                 "/swagger-ui.html") // 스웨거
@@ -67,6 +65,9 @@ public class SecurityConfig {
 
         // 소셜 로그인 설정
         .oauth2Login(oauth2 -> oauth2
+            .authorizationEndpoint(endpoint -> endpoint
+                .baseUri("/oauth/login")
+            )
             .userInfoEndpoint(userInfo -> userInfo
                 .userService(customOAuth2UserService) // 유저 정보 가져오는 서비스 등록
             )

--- a/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
                 "/index.html/**",
                 "/ws-stomp/**",
                 "/auth/**", // 소셜 관련 경로 허용
-                "/api/auth/**", // 소셜 관련 경로 허용
+                "/auth/**", // 소셜 관련 경로 허용
                 "/login/**", // 소셜 관련 경로 허용
                 "/oauth2/**", // 소셜 관련 경로 허용
                 "/v3/api-docs/**", // 스웨거

--- a/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
@@ -86,6 +86,7 @@ public class SecurityConfig {
 
     // 프론트엔드 로컬과 배포 주소 모두 허용
     configuration.setAllowedOrigins(Arrays.asList(
+        "https://www.bitelearn.site",
         "http://localhost:5173",
         "https://bitelearn.vercel.app"
     ));

--- a/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
@@ -47,8 +47,8 @@ public class SecurityConfig {
 
         // 요청에 대한 권한 설정
         .authorizeHttpRequests(auth -> auth
-            // 챕터 목록 조회(GET)는 비회원(토큰 없음)도 접근 허용
-            .requestMatchers(HttpMethod.GET, "/learning/chapters").permitAll()
+            // 카테고리, 토픽, 챕터 목록 조회(GET)는 비회원(토큰 없음)도 접근 허용
+            .requestMatchers(HttpMethod.GET, "/learning/chapters", "/learning/categories").permitAll()
 
             // 인증 없이 접근 가능한 경로
             .requestMatchers(

--- a/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                 "/login/**",
                 "/oauth2/**",
                 "/oauth/**",
+                "/actuator/**",
                 "/v3/api-docs/**",
                 "/swagger-ui/**",
                 "/swagger-ui.html"

--- a/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/SecurityConfig.java
@@ -1,0 +1,74 @@
+package com.ogi1t.bitelearn.global.config;
+
+import com.ogi1t.bitelearn.domain.auth.service.CustomOAuth2UserService;
+import com.ogi1t.bitelearn.global.security.JwtAuthenticationFilter;
+import com.ogi1t.bitelearn.global.security.JwtProvider;
+import com.ogi1t.bitelearn.global.security.OAuth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final JwtProvider jwtProvider;
+  private final CustomOAuth2UserService customOAuth2UserService;
+  private final OAuth2SuccessHandler oAuth2SuccessHandler;
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable) // REST API이므로 csrf 보안 필요 없음
+        .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 로그인 비활성화
+        .formLogin(AbstractHttpConfigurer::disable) // 기본 폼 로그인 비활성화
+
+        // 세션을 사용하지 않음 (Stateless)
+        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+        // 요청에 대한 권한 설정
+        .authorizeHttpRequests(auth -> auth
+            // 인증 없이 접근 가능한 경로
+            .requestMatchers(
+                "/index.html/**",
+                "/ws-stomp/**",
+                "/auth/**", // 소셜 관련 경로 허용
+                "/api/auth/**", // 소셜 관련 경로 허용
+                "/login/**", // 소셜 관련 경로 허용
+                "/oauth2/**", // 소셜 관련 경로 허용
+                "/v3/api-docs/**", // 스웨거
+                "/swagger-ui/**", // 스웨거
+                "/swagger-ui.html") // 스웨거
+            // 그 외 모든 요청은 인증 필요
+            .permitAll()
+            .anyRequest().authenticated()
+        )
+
+        // 소셜 로그인 설정
+        .oauth2Login(oauth2 -> oauth2
+            .userInfoEndpoint(userInfo -> userInfo
+                .userService(customOAuth2UserService) // 유저 정보 가져오는 서비스 등록
+            )
+            .successHandler(oAuth2SuccessHandler)     // 로그인 성공 시 처리 핸들러 등록
+        )
+
+        // JWT 필터 등록
+        .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.ogi1t.bitelearn.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    // JWT 설정
+    String jwtSchemeName = "jwtAuth";
+    SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+    Components components = new Components()
+        .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+            .name(jwtSchemeName)
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT"));
+
+    return new OpenAPI()
+        .info(new Info()
+            .title("404Jerry API 명세서")
+            .description("스프링 부트 API 명세서입니다.")
+            .version("v1.0.0"))
+        .addSecurityItem(securityRequirement)
+        .components(components);
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/config/SwaggerConfig.java
@@ -26,7 +26,7 @@ public class SwaggerConfig {
 
     return new OpenAPI()
         .info(new Info()
-            .title("404Jerry API 명세서")
+            .title("Bitelearn API 명세서")
             .description("스프링 부트 API 명세서입니다.")
             .version("v1.0.0"))
         .addSecurityItem(securityRequirement)

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/ApiCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/ApiCode.java
@@ -1,0 +1,10 @@
+package com.ogi1t.bitelearn.global.exception;
+
+public interface ApiCode {
+
+    Integer getHttpStatus();  // HTTP status (200, 201, 400 ...)
+
+    Integer getCode();        // 서비스 내부 코드(원하면 HTTP와 동일하게 써도 됨)
+
+    String getMessage();      // 사용자/클라에 내려줄 기본 메시지
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/BusinessException.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/BusinessException.java
@@ -1,0 +1,28 @@
+package com.ogi1t.bitelearn.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+  private final ApiCode code;
+  private final String detailMessage; // optional
+
+  public BusinessException(ApiCode code) {
+    super(code.getMessage());
+    this.code = code;
+    this.detailMessage = null;
+  }
+
+  public BusinessException(ApiCode code, String detailMessage) {
+    super(code.getMessage());
+    this.code = code;
+    this.detailMessage = detailMessage;
+  }
+
+  public String resolvedMessage() {
+    return (detailMessage == null || detailMessage.isBlank())
+        ? code.getMessage()
+        : detailMessage;
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/CommonErrorCode.java
@@ -1,0 +1,19 @@
+package com.ogi1t.bitelearn.global.exception;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum CommonErrorCode implements ApiCode {
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), 400, "잘못된 요청"),
+    MISSING_REQUIRED_HEADER(HttpStatus.BAD_REQUEST.value(), 400, "필수 헤더가 누락되었습니다"),
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), 500, "서버 에러");
+
+    private final Integer httpStatus;
+    private final Integer code;
+    private final String message;
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.ogi1t.bitelearn.global.exception;
+
+import com.ogi1t.bitelearn.global.exception.dto.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusiness(BusinessException e) {
+        ApiCode code = e.getCode();
+        return ResponseEntity
+                .status(code.getHttpStatus())
+                .body(new ErrorResponse(code.getCode(), e.resolvedMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleAny(Exception e) {
+        ApiCode code = CommonErrorCode.SERVER_ERROR;
+        return ResponseEntity
+                .status(code.getHttpStatus())
+                .body(new ErrorResponse(code.getCode(), code.getMessage()));
+    }
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/domain/AuthErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/domain/AuthErrorCode.java
@@ -1,0 +1,20 @@
+package com.ogi1t.bitelearn.global.exception.domain;
+
+import com.ogi1t.bitelearn.global.exception.ApiCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum AuthErrorCode implements ApiCode {
+
+  EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST.value(), 400, "이미 존재하는 이메일입니다."),
+  LOGIN_FAILED(HttpStatus.UNAUTHORIZED.value(), 401, "아이디 또는 비밀번호가 잘못되었습니다."),
+  INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), 401, "유효하지 않은 리프레시 토큰입니다."),
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 유저입니다.");
+
+  private final Integer httpStatus;
+  private final Integer code;
+  private final String message;
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/domain/AuthErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/domain/AuthErrorCode.java
@@ -12,6 +12,7 @@ public enum AuthErrorCode implements ApiCode {
   EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST.value(), 400, "이미 존재하는 이메일입니다."),
   LOGIN_FAILED(HttpStatus.UNAUTHORIZED.value(), 401, "아이디 또는 비밀번호가 잘못되었습니다."),
   INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), 401, "유효하지 않은 리프레시 토큰입니다."),
+  EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), 401, "만료된 리프레시 토큰입니다."),
   USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 유저입니다.");
 
   private final Integer httpStatus;

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/domain/DashboardErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/domain/DashboardErrorCode.java
@@ -1,0 +1,17 @@
+package com.ogi1t.bitelearn.global.exception.domain;
+
+import com.ogi1t.bitelearn.global.exception.ApiCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum DashboardErrorCode implements ApiCode {
+
+  UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED.value(), 401, "대시보드 추천 학습을 보려면 로그인이 필요합니다.");
+
+  private final Integer httpStatus;
+  private final Integer code;
+  private final String message;
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/domain/LearningErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/domain/LearningErrorCode.java
@@ -13,7 +13,8 @@ public enum LearningErrorCode implements ApiCode {
   CHAPTER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 챕터입니다."),
   QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 퀴즈입니다."),
   PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "학습 진행도 정보를 찾을 수 없습니다."),
-  INVALID_QUIZ_SUBMISSION(HttpStatus.BAD_REQUEST.value(), 400, "잘못된 퀴즈 제출 요청입니다.");
+  INVALID_QUIZ_SUBMISSION(HttpStatus.BAD_REQUEST.value(), 400, "잘못된 퀴즈 제출 요청입니다."),
+  NOTE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 오답 노트입니다.");
 
   private final Integer httpStatus;
   private final Integer code;

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/domain/LearningErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/domain/LearningErrorCode.java
@@ -13,8 +13,7 @@ public enum LearningErrorCode implements ApiCode {
   CHAPTER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 챕터입니다."),
   QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 퀴즈입니다."),
   PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "학습 진행도 정보를 찾을 수 없습니다."),
-  INVALID_QUIZ_SUBMISSION(HttpStatus.BAD_REQUEST.value(), 400, "잘못된 퀴즈 제출 요청입니다."),
-  NOTE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 오답 노트입니다.");
+  INVALID_QUIZ_SUBMISSION(HttpStatus.BAD_REQUEST.value(), 400, "잘못된 퀴즈 제출 요청입니다.");
 
   private final Integer httpStatus;
   private final Integer code;

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/domain/LearningErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/domain/LearningErrorCode.java
@@ -1,0 +1,21 @@
+package com.ogi1t.bitelearn.global.exception.domain;
+
+import com.ogi1t.bitelearn.global.exception.ApiCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum LearningErrorCode implements ApiCode {
+
+  UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED.value(), 401, "로그인이 필요한 학습 서비스입니다."),
+  CHAPTER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 챕터입니다."),
+  QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 퀴즈입니다."),
+  PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "학습 진행도 정보를 찾을 수 없습니다."),
+  INVALID_QUIZ_SUBMISSION(HttpStatus.BAD_REQUEST.value(), 400, "잘못된 퀴즈 제출 요청입니다.");
+
+  private final Integer httpStatus;
+  private final Integer code;
+  private final String message;
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/domain/NoteErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/domain/NoteErrorCode.java
@@ -1,0 +1,18 @@
+package com.ogi1t.bitelearn.global.exception.domain;
+
+import com.ogi1t.bitelearn.global.exception.ApiCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum NoteErrorCode implements ApiCode {
+
+  NOTE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 오답 노트 기록입니다."),
+  UNAUTHORIZED_NOTE_ACCESS(HttpStatus.FORBIDDEN.value(), 403, "본인의 오답 노트만 조회할 수 있습니다.");
+
+  private final Integer httpStatus;
+  private final Integer code;
+  private final String message;
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/domain/UserErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/domain/UserErrorCode.java
@@ -1,0 +1,18 @@
+package com.ogi1t.bitelearn.global.exception.domain;
+
+import com.ogi1t.bitelearn.global.exception.ApiCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum UserErrorCode implements ApiCode {
+
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 유저입니다."),
+  NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST.value(), 400, "이미 사용 중인 닉네임입니다.");
+
+  private final Integer httpStatus;
+  private final Integer code;
+  private final String message;
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/domain/UserErrorCode.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/domain/UserErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ApiCode {
 
   USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 404, "존재하지 않는 유저입니다."),
-  NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST.value(), 400, "이미 사용 중인 닉네임입니다.");
+  NICKNAME_DUPLICATION(HttpStatus.CONFLICT.value(), 409, "이미 사용 중인 닉네임입니다.");
 
   private final Integer httpStatus;
   private final Integer code;

--- a/src/main/java/com/ogi1t/bitelearn/global/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/exception/dto/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.ogi1t.bitelearn.global.exception.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private final Integer code;   // 서비스 내부 코드 (httpStatus와 분리)
+    private final String message; // 클라이언트 메시지
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/security/CustomPrincipal.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/security/CustomPrincipal.java
@@ -1,0 +1,66 @@
+package com.ogi1t.bitelearn.global.security;
+
+import com.ogi1t.bitelearn.domain.auth.entity.enums.ProviderType;
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Getter
+public class CustomPrincipal implements UserDetails, OAuth2User {
+
+  private final Long userId;
+  private final String email;
+  private final ProviderType providerType;
+  private final Collection<? extends GrantedAuthority> authorities;
+  private Map<String, Object> attributes; // OAuth2 로그인 시에만 값 있음
+
+  // 생성자: OAuth2 로그인 용
+  public CustomPrincipal(User user, Map<String, Object> attributes) {
+    this.userId = user.getId();
+    this.email = user.getEmail();
+    this.providerType = user.getProviderType();
+    this.authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
+    this.attributes = attributes;
+  }
+
+  // 생성자: JWT 필터 인증 용 (attributes 없음)
+  public CustomPrincipal(Long userId, String email, ProviderType providerType) {
+    this.userId = userId;
+    this.email = email;
+    this.providerType = providerType;
+    this.authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
+  }
+
+  // --- OAuth2User 구현 ---
+  @Override
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public String getName() {
+    return email;
+  }
+
+  // --- UserDetails 구현 ---
+  @Override
+  public String getUsername() { return email; } // 우리는 email을 ID로 씀
+  @Override
+  public String getPassword() { return null; } // 소셜로그인은 비번 없음
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }
+  @Override
+  public boolean isAccountNonExpired() { return true; }
+  @Override
+  public boolean isAccountNonLocked() { return true; }
+  @Override
+  public boolean isCredentialsNonExpired() { return true; }
+  @Override
+  public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.ogi1t.bitelearn.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  public static final String AUTHORIZATION_HEADER = "Authorization";
+  public static final String BEARER_PREFIX = "Bearer ";
+
+  private final JwtProvider jwtProvider;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+    // 1. Request Header 에서 토큰을 꺼냄
+    String jwt = resolveToken(request);
+
+    // 2. validateToken 으로 토큰 유효성 검사
+    if (StringUtils.hasText(jwt) && jwtProvider.validateAccessToken(jwt)) {
+      // 3. 토큰이 유효하면 토큰에서 Authentication 객체를 가지고 와서 SecurityContext 에 저장
+      Authentication authentication = jwtProvider.getAuthentication(jwt);
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  // Request Header 에서 토큰 정보 추출
+  private String resolveToken(HttpServletRequest request) {
+    String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+      return bearerToken.substring(7);
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/security/JwtProvider.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/security/JwtProvider.java
@@ -1,0 +1,131 @@
+package com.ogi1t.bitelearn.global.security;
+
+import com.ogi1t.bitelearn.domain.auth.entity.enums.ProviderType;
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import javax.crypto.SecretKey;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+  private final SecretKey accSecretKey;
+  private final SecretKey refSecretKey;
+  @Getter
+  private final long accessTokenExpirationTime;
+  private final long refreshTokenExpirationTime;
+
+  public JwtProvider(
+      @Value("${jwt.accsecret}") String accSecretKey,
+      @Value("${jwt.refsecret}") String refSecretKey,
+      @Value("${jwt.access-token-expiration}") long accessTokenExpirationTime,
+      @Value("${jwt.refresh-token-expiration}") long refreshTokenExpirationTime
+  ) {
+    byte[] accKeyBytes = Decoders.BASE64.decode(accSecretKey);
+    byte[] refKeyBytes = Decoders.BASE64.decode(refSecretKey);
+    this.accSecretKey = Keys.hmacShaKeyFor(accKeyBytes);
+    this.refSecretKey = Keys.hmacShaKeyFor(refKeyBytes);
+    this.accessTokenExpirationTime = accessTokenExpirationTime;
+    this.refreshTokenExpirationTime = refreshTokenExpirationTime;
+  }
+
+  // Access Token 생성
+  public String createAccessToken(Long userId, String email, String nickname, ProviderType provider) {
+    return Jwts.builder()
+        .setSubject(String.valueOf(userId)) // PK를 Subject로 설정
+        .claim("email", email)              // 이메일
+        .claim("nickname", nickname)        // 닉네임
+        .claim("provider", provider)        // 가입 경로
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpirationTime))
+        .signWith(accSecretKey, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  // Refresh Token 생성
+  public String createRefreshToken(Long userId) {
+    return Jwts.builder()
+        .setSubject(String.valueOf(userId))
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpirationTime))
+        .signWith(refSecretKey, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  // 토큰에서 CustomPrincipal 객체를 만들어서 넣음
+  public Authentication getAuthentication(String token) {
+    Claims claims = getACCClaims(token);
+
+    // 1. 토큰에 담긴 정보 꺼내기
+    String userIdStr = claims.getSubject();
+    Long userId = Long.valueOf(userIdStr);
+    String email = claims.get("email", String.class);
+    String nickname = claims.get("nickname", String.class);
+    // enum 변환 (String -> Enum)
+    String providerStr = claims.get("provider", String.class);
+    ProviderType providerType = ProviderType.valueOf(providerStr);
+
+    // 2. 임시 User 객체 생성 (DB 조회를 줄이기 위해 토큰 정보로 만듦)
+    // 필요한 필드만 채웁니다. (비밀번호 등은 몰라도 됨)
+    User user = User.builder()
+        .id(userId)
+        .email(email)
+        .nickname(nickname)
+        .providerType(providerType)
+        .build();
+
+    // 3. CustomPrincipal 생성
+    CustomPrincipal principal = new CustomPrincipal(user, new HashMap<>());
+
+    // 4. Authentication 객체 반환 (이제 Principal은 String이 아니라 객체임!)
+    List<SimpleGrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+    return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+  }
+
+  public boolean validateAccessToken(String token) {
+    return validateToken(token, accSecretKey);
+  }
+
+  public boolean validateRefreshToken(String token) {
+    return validateToken(token, refSecretKey);
+  }
+
+  private boolean validateToken(String token, SecretKey secretKey) {
+    try {
+      Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+      return true;
+    } catch (SecurityException | MalformedJwtException e) {
+      log.warn("잘못된 JWT 서명입니다.");
+    } catch (ExpiredJwtException e) {
+      log.info("만료된 JWT 토큰입니다.");
+    } catch (UnsupportedJwtException e) {
+      log.error("지원되지 않는 JWT 토큰입니다.");
+    } catch (IllegalArgumentException e) {
+      log.info("JWT 토큰이 잘못되었습니다.");
+    }
+    return false;
+  }
+
+  private Claims getACCClaims(String token) {
+    return Jwts.parserBuilder().setSigningKey(accSecretKey).build().parseClaimsJws(token).getBody();
+  }
+}

--- a/src/main/java/com/ogi1t/bitelearn/global/security/JwtProvider.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/security/JwtProvider.java
@@ -2,6 +2,8 @@ package com.ogi1t.bitelearn.global.security;
 
 import com.ogi1t.bitelearn.domain.auth.entity.enums.ProviderType;
 import com.ogi1t.bitelearn.domain.user.entity.User;
+import com.ogi1t.bitelearn.global.exception.BusinessException;
+import com.ogi1t.bitelearn.global.exception.domain.AuthErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -105,8 +107,20 @@ public class JwtProvider {
     return validateToken(token, accSecretKey);
   }
 
-  public boolean validateRefreshToken(String token) {
-    return validateToken(token, refSecretKey);
+  public void validateRefreshToken(String token) {
+    if (token == null || token.trim().isEmpty()) {
+      throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    try {
+      Jwts.parserBuilder().setSigningKey(refSecretKey).build().parseClaimsJws(token);
+    } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+      log.warn("유효하지 않은 JWT 토큰입니다: {}", e.getMessage());
+      throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+    } catch (ExpiredJwtException e) {
+      log.info("만료된 JWT 토큰입니다.");
+      throw new BusinessException(AuthErrorCode.EXPIRED_REFRESH_TOKEN);
+    }
   }
 
   private boolean validateToken(String token, SecretKey secretKey) {

--- a/src/main/java/com/ogi1t/bitelearn/global/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/security/OAuth2SuccessHandler.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
@@ -76,8 +77,16 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         .build();
     response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-    // 2. Access Token을 쿼리 파라미터에 담아서 프론트엔드로 리다이렉트
-    String targetUrl = frontendRedirectUrl + accessToken;
+    // 만료 시간 설정
+    long accessTokenExpiresIn = 1800; // 1800초 (30분)
+
+    // 2. UriComponentsBuilder를 사용해 안전하게 URL 생성
+    String targetUrl = UriComponentsBuilder.fromUriString(frontendRedirectUrl)
+        .queryParam("accessToken", accessToken)
+        .queryParam("accessTokenExpiresIn", accessTokenExpiresIn)
+        .build()
+        .toUriString();
+
     getRedirectStrategy().sendRedirect(request, response, targetUrl);
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/global/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/security/OAuth2SuccessHandler.java
@@ -28,10 +28,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
   private final JwtProvider jwtProvider;
   private final RefreshTokenRepository refreshTokenRepository;
   private final UserRepository userRepository;
-  private final ObjectMapper objectMapper;
 
   @Value("${app.frontend-redirect-url}")
   private String frontendRedirectUrl;
+
+  @Value("${jwt.access-token-expiration}")
+  private long accessTokenExpirationTime;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -77,13 +79,10 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         .build();
     response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-    // 만료 시간 설정
-    long accessTokenExpiresIn = 1800; // 1800초 (30분)
-
     // 2. UriComponentsBuilder를 사용해 안전하게 URL 생성
     String targetUrl = UriComponentsBuilder.fromUriString(frontendRedirectUrl)
         .queryParam("accessToken", accessToken)
-        .queryParam("accessTokenExpiresIn", accessTokenExpiresIn)
+        .queryParam("accessTokenExpiresIn", accessTokenExpirationTime)
         .build()
         .toUriString();
 

--- a/src/main/java/com/ogi1t/bitelearn/global/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/security/OAuth2SuccessHandler.java
@@ -70,8 +70,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
         .maxAge(14 * 24 * 60 * 60) // 14일
         .path("/")
-        .secure(false) // HTTPS 적용 시 true로 변경 필수
-        .sameSite("Lax") // 프론트/백엔드 도메인 상황에 따라 None 또는 Strict로 변경
+        .secure(true) // HTTPS 적용으로 true로 변경
+        .sameSite("None") // HTTPS 적용으로 None으로 변경
         .httpOnly(true)
         .build();
     response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());

--- a/src/main/java/com/ogi1t/bitelearn/global/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/security/OAuth2SuccessHandler.java
@@ -2,7 +2,6 @@ package com.ogi1t.bitelearn.global.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ogi1t.bitelearn.domain.auth.entity.RefreshToken;
-import com.ogi1t.bitelearn.domain.auth.dto.response.TokenResponse;
 import com.ogi1t.bitelearn.domain.auth.repository.RefreshTokenRepository;
 import com.ogi1t.bitelearn.domain.user.entity.User;
 import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
@@ -13,6 +12,9 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -26,6 +28,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
   private final RefreshTokenRepository refreshTokenRepository;
   private final UserRepository userRepository;
   private final ObjectMapper objectMapper;
+
+  @Value("${app.frontend-redirect-url}")
+  private String frontendRedirectUrl;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -60,17 +65,19 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         .expiredAt(LocalDateTime.now().plusDays(14))
         .build());
 
-    // 5. 응답 전송 (JSON으로 뿌려주기)
-    // 실제 운영 시에는 프론트엔드 URL로 리다이렉트(sendRedirect) 해야 함
-    // response.sendRedirect("http://localhost:3000/oauth/callback?access=" + accessToken);
-    response.setContentType("application/json;charset=UTF-8");
-    TokenResponse tokenResponse = TokenResponse.builder()
-        .grantType("Bearer")
-        .accessToken(accessToken)
-        .refreshToken(refreshToken)
-        .accessTokenExpiresIn(jwtProvider.getAccessTokenExpirationTime())
+    // 쿠키 설정
+    // 1. Refresh Token을 HttpOnly 쿠키로 설정
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        .maxAge(14 * 24 * 60 * 60) // 14일
+        .path("/")
+        .secure(false) // HTTPS 적용 시 true로 변경 필수
+        .sameSite("Lax") // 프론트/백엔드 도메인 상황에 따라 None 또는 Strict로 변경
+        .httpOnly(true)
         .build();
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-    response.getWriter().write(objectMapper.writeValueAsString(tokenResponse));
+    // 2. Access Token을 쿼리 파라미터에 담아서 프론트엔드로 리다이렉트
+    String targetUrl = frontendRedirectUrl + accessToken;
+    getRedirectStrategy().sendRedirect(request, response, targetUrl);
   }
 }

--- a/src/main/java/com/ogi1t/bitelearn/global/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ogi1t/bitelearn/global/security/OAuth2SuccessHandler.java
@@ -1,0 +1,76 @@
+package com.ogi1t.bitelearn.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ogi1t.bitelearn.domain.auth.entity.RefreshToken;
+import com.ogi1t.bitelearn.domain.auth.dto.response.TokenResponse;
+import com.ogi1t.bitelearn.domain.auth.repository.RefreshTokenRepository;
+import com.ogi1t.bitelearn.domain.user.entity.User;
+import com.ogi1t.bitelearn.domain.user.repository.UserRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+  private final JwtProvider jwtProvider;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final UserRepository userRepository;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+    // 1. 로그인된 유저 정보 가져오기
+    CustomPrincipal principal = (CustomPrincipal) authentication.getPrincipal();
+
+    log.info("소셜 로그인 성공! 이메일: {}", principal.getEmail());
+
+    // 2. DB에서 유저 조회하여 닉네임 가져오기
+    User user = userRepository.findById(principal.getUserId())
+        .orElseThrow(() -> new RuntimeException("유저 정보를 찾을 수 없습니다."));
+
+    // 3. JWT 토큰 생성
+    String accessToken = jwtProvider.createAccessToken(
+        user.getId(),
+        user.getEmail(),
+        user.getNickname(),
+        user.getProviderType()
+    );
+
+    String refreshToken = jwtProvider.createRefreshToken(
+        user.getId()
+    );
+
+    // 4. Refresh Token DB 저장
+    refreshTokenRepository.deleteByUserId(user.getId());
+    refreshTokenRepository.save(RefreshToken.builder()
+        .userId(user.getId())
+        .token(refreshToken)
+        .createdAt(LocalDateTime.now())
+        .expiredAt(LocalDateTime.now().plusDays(14))
+        .build());
+
+    // 5. 응답 전송 (JSON으로 뿌려주기)
+    // 실제 운영 시에는 프론트엔드 URL로 리다이렉트(sendRedirect) 해야 함
+    // response.sendRedirect("http://localhost:3000/oauth/callback?access=" + accessToken);
+    response.setContentType("application/json;charset=UTF-8");
+    TokenResponse tokenResponse = TokenResponse.builder()
+        .grantType("Bearer")
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .accessTokenExpiresIn(jwtProvider.getAccessTokenExpirationTime())
+        .build();
+
+    response.getWriter().write(objectMapper.writeValueAsString(tokenResponse));
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,8 @@
 spring:
+  profiles:
+    active: prd # 기본값을 dev로 설정하면 로컬에서 실행할 때 편리해요.
+  # 공통 설정 (애플리케이션 이름 등)
   application:
     name: bitelearn
 app:
-  frontend-redirect-url: "http://15.164.238.132:3000/oauth/callback?accessToken="
+  frontend-redirect-url: "http://localhost:5173/oauth/callback?accessToken="

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,5 @@
 spring:
   application:
     name: bitelearn
+app:
+  frontend-redirect-url: "http://15.164.238.132:3000/oauth/callback?accessToken="

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,3 +6,11 @@ spring:
     name: bitelearn
 server:
   forward-headers-strategy: framework
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus # 건강 상태와 프로메테우스용 데이터 오픈
+  metrics:
+    tags:
+      application: bitelearn-api # 우리 앱 이름표 달기

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,4 +5,4 @@ spring:
   application:
     name: bitelearn
 app:
-  frontend-redirect-url: "http://localhost:5173/oauth/callback?accessToken="
+  frontend-redirect-url: "http://localhost:5173/oauth/callback"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,3 +6,5 @@ spring:
     name: bitelearn
 app:
   frontend-redirect-url: "http://localhost:5173/oauth/callback"
+server:
+  forward-headers-strategy: framework

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,5 @@ spring:
   # 공통 설정 (애플리케이션 이름 등)
   application:
     name: bitelearn
-app:
-  frontend-redirect-url: "http://localhost:5173/oauth/callback"
 server:
   forward-headers-strategy: framework


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#1 ~ #50 

## 📝 PR 개요

사회 초년생을 위한 부동산·금융·세무 마이크로 러닝 플랫폼, **BiteLearn**의 v1.0.0 (MVP) 정식 릴리즈를 위해 `develop` 브랜치의 최종 통합본을 운영(Production) 환경인 `main` 브랜치로 병합합니다.

## 📜 변경 사항

**[1. 인프라 및 아키텍처 세팅]**
- AWS EC2, RDS(MySQL), S3 기반의 Stateless 백엔드 환경 구축
- Route 53 + ALB + ACM을 활용한 전 구간 HTTPS 암호화 통신 적용
- Docker & Jenkins 기반의 CI/CD 자동화 파이프라인 구축 완료

**[2. 보안 및 인증 (Auth)]**
- JWT 기반 자체 로그인 및 OAuth 2.0 (Google, Naver) 소셜 로그인 통합
- Refresh Token에 `HttpOnly`, `Secure`, `SameSite=None` 쿠키 정책을 적용하여 XSS/CSRF 취약점 방어

**[3. 핵심 비즈니스 로직 (Learning & Note)]**
- JSON 타입을 활용한 다형성 퀴즈 데이터 모델링 (`SpecificData`)
- 무결성 보장을 위한 오답 노트 스냅샷 패턴(비정규화) 도입
- 대용량 데이터 조회를 위한 커서 기반 페이지네이션(No-Offset) 적용
- 오답 노트 무한 스크롤 API 성능 최적화 (복합 인덱스 추가로 응답 속도 79% 개선)

**[4. 대시보드 (Dashboard)]**
- 유저의 학습 이력 데이터를 기반으로 한 미학습 토픽 최우선 랜덤 추천 로직 구현

## 📸 스크린샷 (선택) 

<img width="2032" height="1167" alt="스크린샷 2026-03-26 오전 4 05 22" src="https://github.com/user-attachments/assets/94655202-171b-428b-bb14-defafa5a5a67" />